### PR TITLE
Create index if it does not exist when querying table

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Change to `lightcopy:parquet-index:0.1.0-s_2.11` for Scala 2.11.x
 Currently supported options, use `--conf key=value` on a command line to provide options similar to
 other Spark configuration or add them to `spark-defaults.conf` file.
 
-| Name | Since | Example | Description |
-|------|:-----:|:-------:|-------------|
-| `spark.sql.index.metastore` | `0.1.0` | _file:/folder, hdfs://host:port/folder_ | Index metastore location, by default uses current working directory; created if does not exist
-| `spark.sql.index.parquet.bloom.enabled` | `0.1.0` | _true, false_ | When set to true, writes bloom filters for indexed columns when creating table index; by default is `false`
-| `spark.sql.index.createIfNotExists` | `0.2.0` | _true, false_ | When set to true, creates index if one does not exist in metastore for the table (will use all available columns for indexing)
+| Name | Since | Example | Description | Default |
+|------|:-----:|:-------:|-------------|---------|
+| `spark.sql.index.metastore` | `0.1.0` | _file:/folder, hdfs://host:port/folder_ | Index metastore location, created if does not exist | _working directory_
+| `spark.sql.index.parquet.bloom.enabled` | `0.1.0` | _true, false_ | When set to true, writes bloom filters for indexed columns when creating table index | _false_
+| `spark.sql.index.createIfNotExists` | `0.2.0` | _true, false_ | When set to true, creates index if one does not exist in metastore for the table (will use all available columns for indexing) | _false_
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Currently only these types are supported for indexed columns:
 - `StringType`
 
 ### Limitations
-- At least one indexed column should be provided, package does not store just schema
 - Indexed columns must be top level primitive columns with types above
 - Indexed columns cannot be the same as partitioning columns (which kind of makes sense)
 - Append mode is not supported for Parquet table when creating index
@@ -65,10 +64,14 @@ other Spark configuration or add them to `spark-defaults.conf` file.
 |------|:-----:|:-------:|-------------|
 | `spark.sql.index.metastore` | `0.1.0` | _file:/folder, hdfs://host:port/folder_ | Index metastore location, by default uses current working directory; created if does not exist
 | `spark.sql.index.parquet.bloom.enabled` | `0.1.0` | _true, false_ | When set to true, writes bloom filters for indexed columns when creating table index; by default is `false`
+| `spark.sql.index.createIfNotExists` | `0.2.0` | _true, false_ | When set to true, creates index if one does not exist in metastore for the table (will use all available columns for indexing)
 
 ## Example
 
 ### Scala API
+Most of the API is defined in [DataFrameIndexManager](./src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala).
+Usage is similar to Spark's `DataFrameReader`, but for `spark.index`.
+
 ```scala
 // Create dummy table "codes.parquet", use repartition to create more or less generic
 // situation with value distribution
@@ -82,6 +85,7 @@ spark.range(0, 10000).
 import com.github.lightcopy.implicits._
 
 // All Spark SQL modes are available (append, overwrite, ignore, error)
+// You can also use `.indexByAll` to index by all inferred columns
 spark.index.create.
   mode("overwrite").indexBy($"id", $"code").parquet("temp/codes.parquet")
 

--- a/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
+++ b/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
@@ -165,6 +165,13 @@ private[sql] case class CreateIndexCommand(
     indexBy(col(columnName), columnNames.map(col): _*)
   }
 
+  /** Index all available columns that can be indexed */
+  def indexByAll(): CreateIndexCommand = {
+    // assign empty list, will infer all columns, see `MetastoreSupport` API for more info
+    this.columns = Nil
+    this
+  }
+
   /**
    * Path to the table to build index for, can be local file system or HDFS.
    * @param path

--- a/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
+++ b/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
@@ -165,7 +165,7 @@ private[sql] case class CreateIndexCommand(
     indexBy(col(columnName), columnNames.map(col): _*)
   }
 
-  /** Index all available columns that can be indexed */
+  /** Use all available columns that can be indexed */
   def indexByAll(): CreateIndexCommand = {
     // assign empty list, will infer all columns, see `MetastoreSupport` API for more info
     this.columns = Nil

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexedDataSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexedDataSource.scala
@@ -48,6 +48,13 @@ case class IndexedDataSource(
     val caseInsensitiveOptions = new CaseInsensitiveMap(options)
     providingClass.newInstance() match {
       case s: MetastoreSupport =>
+        // if index does not exist in metastore and option is selected, we will create it before
+        // loading index catalog. Note that empty list of columns indicates all available columns
+        // will be inferred
+        if (metastore.conf.createIfNotExists && !existsIndex()) {
+          logInfo("Index does not exist in metastore, will create for all available columns")
+          createIndex(Nil)
+        }
         logInfo(s"Loading index for $s, table=${tablePath.getPath}")
 
         val indexCatalog = metastore.load(s.identifier, tablePath.getPath) { status =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreSupport.scala
@@ -18,13 +18,12 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.hadoop.fs.FileStatus
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Column
 
 /**
  * Interface [[MetastoreSupport]] to describe how index metadata should be saved or loaded.
  */
-trait MetastoreSupport extends Logging {
+trait MetastoreSupport {
   /**
    * Index path suffix to identify file format to load index.
    * Must be lowercase alpha-numeric characters only.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreSupport.scala
@@ -18,12 +18,13 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.hadoop.fs.FileStatus
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Column
 
 /**
  * Interface [[MetastoreSupport]] to describe how index metadata should be saved or loaded.
  */
-trait MetastoreSupport {
+trait MetastoreSupport extends Logging {
   /**
    * Index path suffix to identify file format to load index.
    * Must be lowercase alpha-numeric characters only.
@@ -45,7 +46,8 @@ trait MetastoreSupport {
    * @param isAppend flag indicates whether or not data should be appended to existing files
    * @param partitionSpec partition spec for table
    * @param partitions all partitions for table (include file status and partition as row)
-   * @param columns sequence of columns to index
+   * @param columns sequence of columns to index, if list is empty, infer all available columns
+   * that can be indexed in the table
    */
   def createIndex(
       metastore: Metastore,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -89,12 +89,8 @@ case class ParquetMetastoreSupport() extends MetastoreSupport {
     }
 
     val partitionSchema = partitionSpec.partitionColumns
-    // prepare index schema by fetching message type from random file
+    // prepare index schema by fetching message type from first partition
     val indexSchema = inferIndexSchema(metastore, partitions, columnNames)
-    if (indexSchema.isEmpty) {
-      throw new UnsupportedOperationException("Index schema must have at least one column, " +
-        s"found $indexSchema, make sure that specified columns are part of table schema")
-    }
     logInfo(s"Resolved index schema ${indexSchema.simpleString}")
 
     // serialized file statuses for Parquet table
@@ -198,9 +194,9 @@ case class ParquetMetastoreSupport() extends MetastoreSupport {
 
 object ParquetMetastoreSupport {
   // internal Hadoop configuration option to set schema for Parquet reader
-  val READ_SCHEMA = "spark.sql.index.parquet.read.schema"
+  private[sql] val READ_SCHEMA = "spark.sql.index.parquet.read.schema"
   // internal Hadoop configuration option to specify bloom filters directory
-  val BLOOM_FILTER_DIR = "spark.sql.index.parquet.bloom.dir"
+  private[sql] val BLOOM_FILTER_DIR = "spark.sql.index.parquet.bloom.dir"
   // metadata name
   val TABLE_METADATA = "_table_metadata"
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.spark.sql.types._
+
+/**
+ * Utility functions to provide list of supported fields, validate and prune columns.
+ */
+object ParquetSchemaUtils {
+  // Supported top-level Spark SQL data types
+  val SUPPORTED_TYPES: Set[DataType] = Set(IntegerType, LongType, StringType)
+
+  /**
+   * Validate input schema as `StructType` and throw exception if schema does not match expected
+   * column types or is empty (see list of supported fields above). Note that this is used in
+   * statistics conversion, so when adding new type, one should update statistics.
+   */
+  def validateStructType(schema: StructType): Unit = {
+    if (schema.isEmpty) {
+      throw new UnsupportedOperationException(s"Empty schema $schema is not supported, please " +
+        s"provide at least one column of a type ${SUPPORTED_TYPES.mkString("[", ", ", "]")}")
+    }
+    schema.fields.foreach { field =>
+      if (!SUPPORTED_TYPES.contains(field.dataType)) {
+        throw new UnsupportedOperationException(
+          "Schema contains unsupported type, " +
+          s"field=$field, " +
+          s"schema=${schema.simpleString}, " +
+          s"supported types=${SUPPORTED_TYPES.mkString("[", ", ", "]")}")
+      }
+    }
+  }
+
+  /**
+   * Prune invalid columns from StructType leaving only supported data types. Only works for
+   * top-level columns at this point.
+   */
+  def pruneStructType(schema: StructType): StructType = {
+    val updatedFields = schema.fields.filter { field =>
+      SUPPORTED_TYPES.contains(field.dataType)
+    }
+    StructType(updatedFields)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -238,7 +238,7 @@ private[parquet] object ParquetStatisticsRDD {
     new TaskAttemptContextImpl(conf, attemptId)
   }
 
-  private def convertColumns(
+  def convertColumns(
       columns: Seq[ColumnChunkMetaData],
       schema: MessageType): Map[String, ParquetColumnMetadata] = {
     val seq = columns.flatMap { column =>
@@ -263,7 +263,7 @@ private[parquet] object ParquetStatisticsRDD {
     seq.map { meta => (meta.fieldName, meta) }.toMap
   }
 
-  private def convertStatistics(parquetStatistics: Statistics[_]): ParquetColumnStatistics = {
+  def convertStatistics(parquetStatistics: Statistics[_]): ParquetColumnStatistics = {
     parquetStatistics match {
       case stats: IntStatistics =>
         ParquetIntStatistics(stats.getMin, stats.getMax, stats.getNumNulls)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -167,9 +167,6 @@ class ParquetStatisticsRDD(
 }
 
 private[parquet] object ParquetStatisticsRDD {
-  // Supported top-level Spark SQL data types
-  val SUPPORTED_TYPES: Set[DataType] = Set(IntegerType, LongType, StringType)
-
   /** Partition data into sequence of buckets with values based on provided number of partitions */
   def partitionData[T: ClassTag](data: Seq[T], numSlices: Int): Seq[Seq[T]] = {
     require(numSlices >= 1, s"Positive number of slices required, found $numSlices")

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -70,6 +70,12 @@ private[spark] object IndexConf {
     doc("When set to true writes bloom filters for indexed columns when creating table index").
     booleanConf.
     createWithDefault(false)
+
+  // If index does not exist in metastore, will create it before querying
+  val CREATE_IF_NOT_EXISTS = IndexConfigBuilder("spark.sql.index.createIfNotExists").
+    doc("When set to true creates index if one does not exist in metastore for the table").
+    booleanConf.
+    createWithDefault(false)
 }
 
 private[spark] class IndexConf extends Serializable {
@@ -86,6 +92,8 @@ private[spark] class IndexConf extends Serializable {
   def metastoreLocation: String = getConf(METASTORE_LOCATION)
 
   def parquetBloomFilterEnabled: Boolean = getConf(PARQUET_BLOOM_FILTER_ENABLED)
+
+  def createIfNotExists: Boolean = getConf(CREATE_IF_NOT_EXISTS)
 
   //////////////////////////////////////////////////////////////
   // == Configuration functionality methods ==

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -67,13 +67,13 @@ private[spark] object IndexConf {
 
   // option to enable/disable bloom filters for Parquet index
   val PARQUET_BLOOM_FILTER_ENABLED = IndexConfigBuilder("spark.sql.index.parquet.bloom.enabled").
-    doc("When set to true writes bloom filters for indexed columns when creating table index").
+    doc("When set to true, writes bloom filters for indexed columns when creating table index").
     booleanConf.
     createWithDefault(false)
 
   // If index does not exist in metastore, will create it before querying
   val CREATE_IF_NOT_EXISTS = IndexConfigBuilder("spark.sql.index.createIfNotExists").
-    doc("When set to true creates index if one does not exist in metastore for the table").
+    doc("When set to true, creates index if one does not exist in metastore for the table").
     booleanConf.
     createWithDefault(false)
 }

--- a/src/test/scala/org/apache/spark/sql/DataFrameIndexManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/DataFrameIndexManagerSuite.scala
@@ -155,6 +155,11 @@ class DataFrameIndexManagerSuite extends UnitTestSuite with SparkLocal {
     ddl.indexBy("a", "b", "c").getColumns should be (Seq(col("a"), col("b"), col("c")))
   }
 
+  test("create command - indexByAll") {
+    val ddl = new DataFrameIndexManager(spark).create
+    ddl.indexByAll().getColumns should be (Nil)
+  }
+
   test("exists command - init") {
     val manager = new DataFrameIndexManager(spark).option("key", "value")
     val ddl = manager.exists

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -29,6 +29,8 @@ import com.github.lightcopy.testutil.{SparkLocal, UnitTestSuite}
 import com.github.lightcopy.testutil.implicits._
 
 class IndexSuite extends UnitTestSuite with SparkLocal {
+  // Reset SparkSession for every test, because Metastore caches instance per session, and we
+  // do not reset options per metastore configuration.
   before {
     startSparkSession()
   }

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -22,17 +22,18 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.internal.IndexConf._
 import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.types._
 
 import com.github.lightcopy.implicits._
 import com.github.lightcopy.testutil.{SparkLocal, UnitTestSuite}
 import com.github.lightcopy.testutil.implicits._
 
 class IndexSuite extends UnitTestSuite with SparkLocal {
-  override def beforeAll {
+  before {
     startSparkSession()
   }
 
-  override def afterAll {
+  after {
     stopSparkSession()
   }
 
@@ -98,6 +99,22 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
     }
   }
 
+  test("create Parquet index with all available columns in the table") {
+    withTempDir { dir =>
+      withSQLConf(METASTORE_LOCATION.key -> dir.toString / "metastore") {
+        spark.range(5).withColumn("str", lit("abc")).withColumn("num", lit(1)).
+          write.parquet(dir.toString / "table")
+        spark.index.create.indexByAll.parquet(dir.toString / "table")
+        spark.index.exists.parquet(dir.toString / "table") should be (true)
+        val df = spark.index.parquet(dir.toString / "table")
+        df.schema should be (StructType(
+          StructField("id", LongType) ::
+          StructField("str", StringType) ::
+          StructField("num", IntegerType) :: Nil))
+      }
+    }
+  }
+
   test("create Parquet index with overwrite mode") {
     withTempDir { dir =>
       withSQLConf(METASTORE_LOCATION.key -> dir.toString / "metastore") {
@@ -151,6 +168,20 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         }
         assert(err.getMessage.contains(
           "ParquetMetastoreSupport does not support append to existing index"))
+      }
+    }
+  }
+
+  test("create index if one does not already exist in metastore when loading") {
+    withTempDir { dir =>
+      withSQLConf(
+          METASTORE_LOCATION.key -> dir.toString / "metastore",
+          CREATE_IF_NOT_EXISTS.key -> "true") {
+        spark.range(0, 9).withColumn("str", lit("abc")).write.parquet(dir.toString / "table")
+        spark.index.exists.parquet(dir.toString / "table") should be (false)
+        val df = spark.index.parquet(dir.toString / "table").filter(col("id") === 1)
+        df.count should be (1)
+        spark.index.exists.parquet(dir.toString / "table") should be (true)
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -115,6 +115,15 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     metastore.getMetastorePath should be (None)
   }
 
+  // test current working directory
+  test("resolveMetastore - empty path provided") {
+    val conf = IndexConf.newConf(spark)
+    conf.setConf(IndexConf.METASTORE_LOCATION, "")
+    val metastore = new Metastore(spark, conf)
+    val path = metastore.resolveMetastore(None, new Configuration(false))
+    assert(path.toString.startsWith(metastore.fs.getWorkingDirectory.toString))
+  }
+
   test("getMetastorePath - local file system path provided") {
     val conf = IndexConf.newConf(spark)
     conf.setConf(IndexConf.METASTORE_LOCATION, "file:/tmp/metastore")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtilsSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.spark.sql.types._
+
+import com.github.lightcopy.testutil.UnitTestSuite
+import com.github.lightcopy.testutil.implicits._
+
+class ParquetSchemaUtilsSuite extends UnitTestSuite {
+  test("validateStructType - empty schema") {
+    val err = intercept[UnsupportedOperationException] {
+      ParquetSchemaUtils.validateStructType(StructType(Nil))
+    }
+    assert(err.getMessage.contains("Empty schema StructType() is not supported"))
+  }
+
+  test("validateStructType - contains unsupported field") {
+    val schema = StructType(
+      StructField("a", IntegerType) ::
+      StructField("b", StringType) ::
+      StructField("c", StructType(
+        StructField("c1", IntegerType) :: Nil)
+      ) :: Nil)
+    val err = intercept[UnsupportedOperationException] {
+      ParquetSchemaUtils.validateStructType(schema)
+    }
+    assert(err.getMessage.contains("Schema contains unsupported type, " +
+      "field=StructField(c,StructType(StructField(c1,IntegerType,true)),true)"))
+  }
+
+  test("validateStructType - all fields are ok") {
+    val schema = StructType(
+      StructField("a", IntegerType) ::
+      StructField("b", StringType) ::
+      StructField("c", LongType) :: Nil)
+    ParquetSchemaUtils.validateStructType(schema)
+  }
+
+  test("pruneStructType - empty schema") {
+    val schema = StructType(Nil)
+    ParquetSchemaUtils.pruneStructType(schema) should be (schema)
+  }
+
+  test("pruneStructType - all supported types") {
+    val schema = StructType(
+      StructField("a", IntegerType) ::
+      StructField("b", LongType) ::
+      StructField("c", StringType) :: Nil)
+    ParquetSchemaUtils.pruneStructType(schema) should be (schema)
+  }
+
+  test("pruneStructType - mix of supported and not supported types") {
+    val schema = StructType(
+      StructField("a", IntegerType) ::
+      StructField("b", LongType) ::
+      StructField("c", StringType) ::
+      StructField("d", BooleanType) ::
+      StructField("e", ArrayType(LongType)) :: Nil)
+
+    val expected = StructType(
+      StructField("a", IntegerType) ::
+      StructField("b", LongType) ::
+      StructField("c", StringType) :: Nil)
+
+    ParquetSchemaUtils.pruneStructType(schema) should be (expected)
+  }
+
+  test("pruneStructType - all not supported types") {
+    val schema = StructType(
+      StructField("a", ArrayType(IntegerType)) ::
+      StructField("b", StructType(
+        StructField("c", LongType) ::
+        StructField("d", StringType) :: Nil)
+      ) :: Nil)
+
+    ParquetSchemaUtils.pruneStructType(schema) should be (StructType(Nil))
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
@@ -16,9 +16,13 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
+import java.io.IOException
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.permission.FsPermission
 
+import org.apache.parquet.column.statistics._
 import org.apache.parquet.schema.MessageTypeParser
 
 import org.apache.spark.SparkException
@@ -67,6 +71,23 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
     part2.iterator.next should be (null)
   }
 
+  test("ParquetStatisticsRDD - partitionData, fail for non-positive slices") {
+    var err = intercept[IllegalArgumentException] {
+      ParquetStatisticsRDD.partitionData(Seq(1, 2, 3), -1)
+    }
+    assert(err.getMessage.contains("Positive number of slices required, found -1"))
+
+    err = intercept[IllegalArgumentException] {
+      ParquetStatisticsRDD.partitionData(Seq(1, 2, 3), 0)
+    }
+    assert(err.getMessage.contains("Positive number of slices required, found 0"))
+  }
+
+  test("ParquetStatisticsRDD - partitionData, partition per element") {
+    val seq = ParquetStatisticsRDD.partitionData(Seq(1, 2, 3), 3)
+    seq should be (Seq(Seq(1), Seq(2), Seq(3)))
+  }
+
   test("ParquetStatisticsRDD - pruneStructType, empty schema") {
     val schema = StructType(Nil)
     ParquetStatisticsRDD.pruneStructType(schema) should be (schema)
@@ -105,6 +126,35 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
       ) :: Nil)
 
     ParquetStatisticsRDD.pruneStructType(schema) should be (StructType(Nil))
+  }
+
+  test("ParquetStatisticsRDD - convertStatistics, integer stats") {
+    val stats = new IntStatistics()
+    stats.setMinMax(1, 2)
+    stats.setNumNulls(5)
+    ParquetStatisticsRDD.convertStatistics(stats) should be (ParquetIntStatistics(1, 2, 5))
+  }
+
+  test("ParquetStatisticsRDD - convertStatistics, long stats") {
+    val stats = new LongStatistics()
+    stats.setMinMax(1L, 2L)
+    stats.setNumNulls(5)
+    ParquetStatisticsRDD.convertStatistics(stats) should be (ParquetLongStatistics(1L, 2L, 5))
+  }
+
+  test("ParquetStatisticsRDD - convertStatistics, string stats") {
+    val stats = new BinaryStatistics()
+    stats.setMinMaxFromBytes("a".getBytes(), "b".getBytes())
+    stats.setNumNulls(5)
+    ParquetStatisticsRDD.convertStatistics(stats) should be (ParquetStringStatistics("a", "b", 5))
+  }
+
+  test("ParquetStatisticsRDD - convertStatistics, unsupported stats") {
+    val stats = new BooleanStatistics()
+    val err = intercept[UnsupportedOperationException] {
+      ParquetStatisticsRDD.convertStatistics(stats)
+    }
+    assert(err.getMessage.contains("Statistics no stats for this column is not supported"))
   }
 
   test("ParquetStatisticsRDD - prepareBloomFilter, empty blocks array") {
@@ -206,6 +256,19 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
       val filter2 = cols("str").filter.get
       filter2.init(new Configuration(false))
       filter2.mightContain("abc") should be (true)
+    }
+  }
+
+  test("ParquetStatisticsRDD - withBloomFilters, fail when cannot create directory") {
+    withTempDir(new FsPermission("444")) { dir =>
+      val context = ParquetStatisticsRDD.taskAttemptContext(new Configuration(false), 1)
+      val schema = MessageTypeParser.parseMessageType(
+        "message spark_schema { required boolean bool; }")
+      val err = intercept[IOException] {
+        ParquetStatisticsRDD.withBloomFilters(schema, context, Array.empty, fs.getFileStatus(dir),
+          fs.getFileStatus(dir))
+      }
+      assert(err.getMessage.contains("Failed to create target directory"))
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
@@ -88,46 +88,6 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
     seq should be (Seq(Seq(1), Seq(2), Seq(3)))
   }
 
-  test("ParquetStatisticsRDD - pruneStructType, empty schema") {
-    val schema = StructType(Nil)
-    ParquetStatisticsRDD.pruneStructType(schema) should be (schema)
-  }
-
-  test("ParquetStatisticsRDD - pruneStructType, all scalar types") {
-    val schema = StructType(
-      StructField("a", IntegerType) ::
-      StructField("b", LongType) ::
-      StructField("c", StringType) :: Nil)
-    ParquetStatisticsRDD.pruneStructType(schema) should be (schema)
-  }
-
-  test("ParquetStatisticsRDD - pruneStructType, mix of supported and not supported types") {
-    val schema = StructType(
-      StructField("a", IntegerType) ::
-      StructField("b", LongType) ::
-      StructField("c", StringType) ::
-      StructField("d", BooleanType) ::
-      StructField("e", ArrayType(LongType)) :: Nil)
-
-    val expected = StructType(
-      StructField("a", IntegerType) ::
-      StructField("b", LongType) ::
-      StructField("c", StringType) :: Nil)
-
-    ParquetStatisticsRDD.pruneStructType(schema) should be (expected)
-  }
-
-  test("ParquetStatisticsRDD - pruneStructType, all not supported types") {
-    val schema = StructType(
-      StructField("a", ArrayType(IntegerType)) ::
-      StructField("b", StructType(
-        StructField("c", LongType) ::
-        StructField("d", StringType) :: Nil)
-      ) :: Nil)
-
-    ParquetStatisticsRDD.pruneStructType(schema) should be (StructType(Nil))
-  }
-
   test("ParquetStatisticsRDD - convertStatistics, integer stats") {
     val stats = new IntStatistics()
     stats.setMinMax(1, 2)


### PR DESCRIPTION
This PR adds option to create index if one does not exist yet in metastore, when querying table. Use `spark.sql.index.createIfNotExists` to specify whether or not you want this behaviour, by default option is `false`.

PR slightly changes internal behaviour, now empty sequence of columns is treated as `all available for index` columns. Previously this would throw exception of empty schema. Again this is done at implementation level, but I added API note saying that this behaviour should be supported.