### PR TITLE
Fix null statistics issue

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/statistics.scala
@@ -204,6 +204,35 @@ case class ParquetStringStatistics(min: String, max: String, numNulls: Long)
   override def getNumNulls(): Long  = numNulls
 }
 
+/**
+ * [[ParquetNullStatistics]] store information for all-nulls column. Statistics is considered
+ * invalid and returns `false` for most of the methods, should be used for filters like
+ * `IsNull` or `IsNotNull`.
+ */
+case class ParquetNullStatistics(numNulls: Long) extends ParquetColumnStatistics {
+
+  require(numNulls >= 0, s"Number of nulls $numNulls is negative")
+
+  override def contains(value: Any): Boolean = value match {
+    case nullValue if nullValue == null && hasNull => true
+    case other => false
+  }
+
+  override def isLessThanMin(value: Any): Boolean = false
+
+  override def isGreaterThanMax(value: Any): Boolean = false
+
+  override def isEqualToMin(value: Any): Boolean = false
+
+  override def isEqualToMax(value: Any): Boolean = false
+
+  override def getMin(): Any = null
+
+  override def getMax(): Any = null
+
+  override def getNumNulls(): Long = numNulls
+}
+
 ////////////////////////////////////////////////////////////////
 // == Supported column filters for Parquet ==
 ////////////////////////////////////////////////////////////////

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/StatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/StatisticsSuite.scala
@@ -422,6 +422,58 @@ class StatisticsSuite extends UnitTestSuite {
     ParquetStringStatistics("b", "d", 1L).isEqualToMax(Array(1, 2, 3)) should be (false)
   }
 
+  // == Null statistics ==
+
+  test("ParquetNullStatistics - invalid statistics") {
+    val err = intercept[IllegalArgumentException] {
+      ParquetNullStatistics(-1)
+    }
+    assert(err.getMessage.contains("Number of nulls -1 is negative"))
+  }
+
+  test("ParquetNullStatistics - valid statistics") {
+    val stats = ParquetNullStatistics(123)
+    stats.hasNull should be (true)
+    stats.getNumNulls should be (123)
+    assert(stats.getMin === null)
+    assert(stats.getMax === null)
+    stats.toString should be ("ParquetNullStatistics(min=null, max=null, nulls=123)")
+  }
+
+  test("ParquetNullStatistics - contains") {
+    val stats = ParquetNullStatistics(123L)
+    stats.contains(null) should be (true)
+    stats.contains("null") should be (false)
+    stats.contains(1) should be (false)
+    stats.contains(Array(1, 2, 3)) should be (false)
+    stats.contains(stats) should be (false)
+  }
+
+  test("ParquetNullStatistics - isLessThanMin") {
+    val stats = ParquetNullStatistics(123L)
+    stats.isLessThanMin(null) should be (false)
+    stats.isLessThanMin(1) should be (false)
+    stats.isLessThanMin("null") should be (false)
+  }
+
+  test("ParquetNullStatistics - isEqualToMin") {
+    val stats = ParquetNullStatistics(123L)
+    stats.isEqualToMin(null) should be (false)
+    stats.isEqualToMin("null") should be (false)
+  }
+
+  test("ParquetNullStatistics - isGreaterThanMax") {
+    val stats = ParquetNullStatistics(123L)
+    stats.isGreaterThanMax(null) should be (false)
+    stats.isGreaterThanMax("null") should be (false)
+  }
+
+  test("ParquetNullStatistics - isEqualToMax") {
+    val stats = ParquetNullStatistics(123L)
+    stats.isEqualToMax(null) should be (false)
+    stats.isEqualToMax("null") should be (false)
+  }
+
   // == Filters ==
 
   test("ParquetBloomFilter - fail to check if not initialized") {


### PR DESCRIPTION
This PR fixes bug when indexing column that has all null values by introducing `ParquetNullStatistics` and updating `convertStatistics` method. Also added 2 tests on correctness for all nulls column filtering and querying when expected 0 rows.