### PR TITLE
Column filter statistics loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ other Spark configuration or add them to `spark-defaults.conf` file.
 | Name | Since | Example | Description | Default |
 |------|:-----:|:-------:|-------------|---------|
 | `spark.sql.index.metastore` | `0.1.0` | _file:/folder, hdfs://host:port/folder_ | Index metastore location, created if does not exist | _working directory_
-| `spark.sql.index.parquet.bloom.enabled` | `0.1.0` | _true, false_ | When set to true, writes bloom filters for indexed columns when creating table index | _false_
+| `spark.sql.index.parquet.filter.enabled` | `0.2.0` | _true, false_ | When set to true, writes filter statistics for indexed columns when creating table index, otherwise only min/max statistics are used. Filter statistics are always used during filtering stage, if can be applied and available | _false_
+| `spark.sql.index.parquet.filter.type` | `0.2.0` | _bloom_ | When filter statistics enabled, selects type of statistics to use when creating index | _bloom_
 | `spark.sql.index.createIfNotExists` | `0.2.0` | _true, false_ | When set to true, creates index if one does not exist in metastore for the table (will use all available columns for indexing) | _false_
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ other Spark configuration or add them to `spark-defaults.conf` file.
 | Name | Since | Example | Description | Default |
 |------|:-----:|:-------:|-------------|---------|
 | `spark.sql.index.metastore` | `0.1.0` | _file:/folder, hdfs://host:port/folder_ | Index metastore location, created if does not exist | _working directory_
-| `spark.sql.index.parquet.filter.enabled` | `0.2.0` | _true, false_ | When set to true, writes filter statistics for indexed columns when creating table index, otherwise only min/max statistics are used. Filter statistics are always used during filtering stage, if can be applied and available | _false_
-| `spark.sql.index.parquet.filter.type` | `0.2.0` | _bloom_ | When filter statistics enabled, selects type of statistics to use when creating index | _bloom_
-| `spark.sql.index.createIfNotExists` | `0.2.0` | _true, false_ | When set to true, creates index if one does not exist in metastore for the table (will use all available columns for indexing) | _false_
+| `spark.sql.index.parquet.filter.enabled` | `0.2.0` | _true, false_ | When set to true, write filter statistics for indexed columns when creating table index, otherwise only min/max statistics are used. Filter statistics are always used during filtering stage, if can be applied and available | _false_
+| `spark.sql.index.parquet.filter.type` | `0.2.0` | _bloom_ | When filter statistics enabled, select type of statistics to use when creating index | _bloom_
+| `spark.sql.index.parquet.filter.eagerLoading` | `0.2.0` | _true, false_ | When set to true, read and load all filter statistics in memory the first time catalog is resolved, otherwise load them lazily as needed when evaluating predicate | _false_
+| `spark.sql.index.createIfNotExists` | `0.2.0` | _true, false_ | When set to true, create index if one does not exist in metastore for the table (will use all available columns for indexing) | _false_
 
 ## Example
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexCatalog.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.catalyst.{expressions, InternalRow}
@@ -29,7 +28,7 @@ import com.github.lightcopy.util.SerializableFileStatus
 
 /**
  * Index catalog for Parquet tables.
- * Metastore is used mainly to provide Hadoop configuration.
+ * Metastore is used mainly to provide Hadoop file system and/or configuration.
  */
 class ParquetIndexCatalog(
     @transient val metastore: Metastore,
@@ -127,12 +126,11 @@ class ParquetIndexCatalog(
   private[parquet] def resolveSupported(
       filter: Filter,
       status: ParquetFileStatus): Filter = {
-    // we need file system and configuration to resolve column filters
+    // we need file system to resolve column filters
     val fs = metastore.fs
-    val conf = metastore.session.sessionState.newHadoopConf()
     require(status.blocks.nonEmpty,
       "Parquet file status has empty blocks, required at least one block metadata")
-    ParquetIndexFilters(fs, conf, status.blocks).foldFilter(filter)
+    ParquetIndexFilters(fs, status.blocks).foldFilter(filter)
   }
 
   private[parquet] def pruneIndexedPartitions(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFilters.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFilters.scala
@@ -16,14 +16,12 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
 
 import org.apache.spark.sql.sources._
 
 private[parquet] case class ParquetIndexFilters(
     fs: FileSystem,
-    conf: Configuration,
     blocks: Array[ParquetBlockMetadata]) {
   /**
    * Transform filter with provided statistics and filter.
@@ -56,7 +54,7 @@ private[parquet] case class ParquetIndexFilters(
           val foundInStats = stats.contains(value)
           if (foundInStats && filter.isDefined) {
             val columnFilter = filter.get
-            columnFilter.readData(fs, conf)
+            columnFilter.readData(fs)
             Trivial(columnFilter.mightContain(value))
           } else {
             Trivial(foundInStats)
@@ -67,7 +65,7 @@ private[parquet] case class ParquetIndexFilters(
           val foundInStats = values.exists(stats.contains)
           if (foundInStats && filter.isDefined) {
             val columnFilter = filter.get
-            columnFilter.readData(fs, conf)
+            columnFilter.readData(fs)
             Trivial(values.exists(columnFilter.mightContain))
           } else {
             Trivial(foundInStats)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -103,8 +103,9 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
 
     val sc = metastore.session.sparkContext
     val hadoopConf = metastore.session.sessionState.newHadoopConf()
-    if (metastore.conf.parquetBloomFilterEnabled) {
+    if (metastore.conf.parquetFilterEnabled) {
       hadoopConf.set(ParquetMetastoreSupport.FILTER_DIR, indexDirectory.getPath.toString)
+      hadoopConf.set(ParquetMetastoreSupport.FILTER_TYPE, metastore.conf.parquetFilterType)
     }
 
     val numPartitions = Math.min(sc.defaultParallelism * 2,
@@ -189,9 +190,11 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
 
 object ParquetMetastoreSupport {
   // internal Hadoop configuration option to set schema for Parquet reader
-  private[sql] val READ_SCHEMA = "spark.sql.index.parquet.read.schema"
-  // internal Hadoop configuration option to specify bloom filters directory
-  private[sql] val FILTER_DIR = "spark.sql.index.parquet.filter.dir"
+  private[sql] val READ_SCHEMA = "spark.sql.hadoop.index.parquet.read.schema"
+  // internal Hadoop configuration option to specify filter directory
+  private[sql] val FILTER_DIR = "spark.sql.hadoop.index.parquet.filter.dir"
+  // internal Hadoop configuration option to specify filter name/type
+  private[sql] val FILTER_TYPE = "spark.sql.hadoop.index.parquet.filter.type"
   // metadata name
   val TABLE_METADATA = "_table_metadata"
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -66,7 +66,7 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
     }
 
     // if eager loading is enabled, load all filter statistics
-    // this operation is done once, catalog will be cached
+    // this operation is done once, catalog will be cached in metastore
     if (metastore.conf.parquetFilterEagerLoading && indexMetadata != null) {
       logInfo("Loading all filter statistics for catalog")
       val startTime = System.nanoTime()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -221,7 +221,7 @@ class ParquetStatisticsRDD(
             blocks.foreach { case (rowCount, map) =>
               map.foreach { case (_, (_, _, filter)) =>
                 if (filter.isDefined) {
-                  filter.get.writeData(fs, configuration)
+                  filter.get.writeData(fs)
                 }
               }
             }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 
 import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputSplit, ParquetRecordReader}
+import org.apache.parquet.hadoop.metadata.BlockMetaData
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.{SparkContext, Partition, TaskContext}
@@ -117,6 +118,8 @@ class ParquetStatisticsRDD(
         fs.getFileStatus(filterPath)
       }
     logDebug(s"Filter directory enabled: ${filterDirectory.isDefined}")
+    val filterType = configuration.get(ParquetMetastoreSupport.FILTER_TYPE)
+    logDebug(s"Filter type selected: ${filterType}")
     // files iterator
     val iter = partition.iterator
 
@@ -150,8 +153,7 @@ class ParquetStatisticsRDD(
               case Some(filterStatus) =>
                 // filename must uniquely identify filter file (file -> block -> column)
                 val filename = ParquetStatisticsRDD.newFilterFile(blockIndex, columnName)
-                val columnFilter = BloomFilterStatistics(block.getRowCount)
-
+                val columnFilter = ParquetStatisticsRDD.newFilter(filterType, block)
                 columnFilter.setPath(filterStatus.getPath.suffix(s"${Path.SEPARATOR}$filename"))
                 (columnIndex, (columnName, statistics, Some(columnFilter)))
               case None =>
@@ -261,12 +263,25 @@ private[parquet] object ParquetStatisticsRDD {
    * Generate new unique filter filename to store filter data, e.g. for bloom filters, based on
    * block index and column name. All special characters are replaced with '_'.
    */
-  def newFilterFile(block: Int, columnName: String): String = {
-    val blockSuffix = String.format("%05d", block.asInstanceOf[Object])
+  def newFilterFile(blockIndex: Int, columnName: String): String = {
+    val blockSuffix = String.format("%05d", blockIndex.asInstanceOf[Object])
     val colSuffix = columnName.map { t =>
       if (t == '/' || t == '\\' || Character.isWhitespace(t)) '_' else t
     }
     s"filter_${UUID.randomUUID}_block${blockSuffix}_col_${colSuffix}"
+  }
+
+  /**
+   * Return new instance of column filter statistics for short name and block metadata.
+   * Block metadata can be used to add additional information about data, e.g. row count for bloom
+   * filter.
+   * We do not add exhaustive match case, because `classForName` checks if short name is invalid.
+   */
+  def newFilter(filterType: String, block: BlockMetaData): ColumnFilterStatistics = {
+    ColumnFilterStatistics.classForName(filterType) match {
+      case clazz if clazz == classOf[BloomFilterStatistics] =>
+        BloomFilterStatistics(block.getRowCount)
+    }
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -57,21 +57,34 @@ private[spark] object IndexConf {
     conf
   }
 
-  // metastore location (root directory in case of file system)
-  // will be created, if it does not exist
   val METASTORE_LOCATION = IndexConfigBuilder("spark.sql.index.metastore").
     doc("Metastore location or root directory to store index information, will be created " +
       "if path does not exist").
     stringConf.
     createWithDefault("")
 
-  // option to enable/disable bloom filters for Parquet index
-  val PARQUET_BLOOM_FILTER_ENABLED = IndexConfigBuilder("spark.sql.index.parquet.bloom.enabled").
-    doc("When set to true, writes bloom filters for indexed columns when creating table index").
+  val PARQUET_FILTER_STATISTICS_ENABLED =
+    IndexConfigBuilder("spark.sql.index.parquet.filter.enabled").
+    doc("When set to true, writes filter statistics for indexed columns when creating table " +
+      "index, otherwise only min/max statistics are used. Filter statistics are always used " +
+      "during filtering stage, if can be applied and available").
     booleanConf.
     createWithDefault(false)
 
-  // If index does not exist in metastore, will create it before querying
+  val PARQUET_FILTER_STATISTICS_TYPE =
+    IndexConfigBuilder("spark.sql.index.parquet.filter.type").
+    doc("When filter statistics enabled, selects type of statistics to use when creating index").
+    stringConf.
+    createWithDefault("bloom")
+
+  val PARQUET_FILTER_STATISTICS_EAGER_LOADING =
+    IndexConfigBuilder("spark.sql.index.parquet.filter.eagerLoading").
+    doc("When set to true, read and load all filter statistics in memory the first time catalog " +
+      "is resolved, otherwise load them lazily as they are needed when evaluating predicate. " +
+      "Eager loading removes IO of reading filter data from disk, but requires extra memory").
+    booleanConf.
+    createWithDefault(false)
+
   val CREATE_IF_NOT_EXISTS = IndexConfigBuilder("spark.sql.index.createIfNotExists").
     doc("When set to true, creates index if one does not exist in metastore for the table").
     booleanConf.
@@ -91,7 +104,11 @@ private[spark] class IndexConf extends Serializable {
 
   def metastoreLocation: String = getConf(METASTORE_LOCATION)
 
-  def parquetBloomFilterEnabled: Boolean = getConf(PARQUET_BLOOM_FILTER_ENABLED)
+  def parquetFilterEnabled: Boolean = getConf(PARQUET_FILTER_STATISTICS_ENABLED)
+
+  def parquetFilterType: String = getConf(PARQUET_FILTER_STATISTICS_TYPE)
+
+  def parquetFilterEagerLoading: Boolean = getConf(PARQUET_FILTER_STATISTICS_EAGER_LOADING)
 
   def createIfNotExists: Boolean = getConf(CREATE_IF_NOT_EXISTS)
 

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -80,7 +80,7 @@ private[spark] object IndexConf {
   val PARQUET_FILTER_STATISTICS_EAGER_LOADING =
     IndexConfigBuilder("spark.sql.index.parquet.filter.eagerLoading").
     doc("When set to true, read and load all filter statistics in memory the first time catalog " +
-      "is resolved, otherwise load them lazily as they are needed when evaluating predicate. " +
+      "is resolved, otherwise load them lazily as needed when evaluating predicate. " +
       "Eager loading removes IO of reading filter data from disk, but requires extra memory").
     booleanConf.
     createWithDefault(false)

--- a/src/main/scala/org/apache/spark/sql/sources/ColumnFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/sources/ColumnFilterStatistics.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.sources
 
 import java.io.{InputStream, OutputStream}
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.util.sketch.BloomFilter
@@ -82,10 +81,18 @@ abstract class ColumnFilterStatistics extends Serializable {
   }
 
   /**
-   * Read data from disk to load filter. This method is safe to call many times, it will check if
-   * filter requires loading, otherwise will be no-op.
+   * Whether or not filter is loaded into memory, implemented as function instead of lazy val.
+   * Added for testing purposes.
    */
-  def readData(fs: FileSystem, conf: Configuration): Unit = {
+  private[sql] def isLoaded(): Boolean = {
+    !needToReadData()
+  }
+
+  /**
+   * Read data from disk to load filter. Operation is done once, so it is safe to call this method
+   * many times, it will check if filter requires loading, otherwise will be no-op.
+   */
+  def readData(fs: FileSystem): Unit = {
     if (needToReadData) {
       var in: InputStream = null
       try {
@@ -103,7 +110,7 @@ abstract class ColumnFilterStatistics extends Serializable {
    * Write filter data onto disk. Method is called only once, when filter is updated with all
    * available data.
    */
-  def writeData(fs: FileSystem, conf: Configuration): Unit = {
+  def writeData(fs: FileSystem): Unit = {
     var out: OutputStream = null
     try {
       out = fs.create(getPath, false)

--- a/src/main/scala/org/apache/spark/sql/sources/ColumnFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/sources/ColumnFilterStatistics.scala
@@ -120,6 +120,22 @@ abstract class ColumnFilterStatistics extends Serializable {
   }
 }
 
+object ColumnFilterStatistics {
+  // Registered classes of filter statistics, key is a short name used in configuration
+  val REGISTERED_FILTERS = Map("bloom" -> classOf[BloomFilterStatistics])
+
+  /**
+   * Get [[ColumnFilterStatistics]] class for short name, used for selecting filter type in
+   * configuration. If short name is not found, throws runtime exception; note that name string is
+   * not modified to find a match (compared as is).
+   */
+  def classForName(name: String): Class[_] = {
+    REGISTERED_FILTERS.getOrElse(name, sys.error(
+      s"Unsupported filter statistics type $name, must be one of " +
+      s"${REGISTERED_FILTERS.keys.mkString("[", ", ", "]")}"))
+  }
+}
+
 /**
  * [[BloomFilterStatistics]] provides filter statistics based on bloom filter per column.
  * Number of expected records `numRows` should only be set when updating records. For read-contains

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -41,6 +41,15 @@ private[datasources] trait TestMetastore {
     conf.setConf(IndexConf.METASTORE_LOCATION, location)
     new Metastore(spark, conf)
   }
+
+  /** Load metastore with set of provided options */
+  def testMetastore(spark: SparkSession, options: Map[String, String]): Metastore = {
+    val conf = IndexConf.newConf(spark)
+    options.foreach { case (key, value) =>
+      conf.setConfString(key, value)
+    }
+    new Metastore(spark, conf)
+  }
 }
 
 class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFiltersSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFiltersSuite.scala
@@ -63,19 +63,19 @@ class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
   test("foldFilter - return trivial when EqualTo attribute is not indexed column") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array(ParquetBlockMetadata(123, Map.empty))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(EqualTo("a", 1)) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(EqualTo("a", 1)) should be (Trivial(true))
   }
 
   test("foldFilter - discard EqualTo when value is not in statistics") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(EqualTo("a", 1)) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(EqualTo("a", 1)) should be (Trivial(false))
   }
 
   test("foldFilter - accept EqualTo when value is in statistics and no filter") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(EqualTo("a", 3)) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(EqualTo("a", 3)) should be (Trivial(true))
   }
 
   test("foldFilter - discard EqualTo when value is in statistics, but rejected by filter") {
@@ -83,7 +83,7 @@ class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
     val blocks = parseColumns(
       ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), Some(TestInFilter(Nil)))
     )
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(EqualTo("a", 3)) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(EqualTo("a", 3)) should be (Trivial(false))
   }
 
   test("foldFilter - accept EqualTo when value is in statistics, and in filter") {
@@ -91,7 +91,7 @@ class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
     val blocks = parseColumns(
       ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), Some(TestInFilter(3 :: Nil)))
     )
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(EqualTo("a", 3)) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(EqualTo("a", 3)) should be (Trivial(true))
   }
 
   test("foldFilter - reduce all blocks results using Or") {
@@ -101,21 +101,21 @@ class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
         ParquetBlockMetadata(1, Map.empty)
     // should return true, because first filter returns Trivial(false), second filter returns
     // Trivial(true), and result is Or(Trivial(true), Trivial(false))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(EqualTo("a", 1)) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(EqualTo("a", 1)) should be (Trivial(true))
   }
 
   test("foldFilter - return true for unsupported filter") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = TestUnsupportedFilter()
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - In, no values match") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(4, 5, 0), None))
     val filter = In("a", Array(1, 2, 3))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - In, no values match, filter used") {
@@ -125,13 +125,13 @@ class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
         Some(TestInFilter(0 :: 5 :: Nil)))
     )
     val filter = In("a", Array(1, 2, 3))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - In, some values match") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(1, 2, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).
+    ParquetIndexFilters(fs, blocks).
       foldFilter(In("a", Array(1, 2, 3))) should be (Trivial(true))
   }
 
@@ -142,217 +142,217 @@ class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
         Some(TestInFilter(1 :: 5 :: Nil)))
     )
     val filter = In("a", Array(1, 2, 3))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - IsNull, non-null statistics") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(IsNull("a")) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(IsNull("a")) should be (Trivial(false))
   }
 
   test("foldFilter - IsNull, null statistics") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 1), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(IsNull("a")) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(IsNull("a")) should be (Trivial(true))
   }
 
   // Curently this filter is not supported, should always return Trivial(true)
   test("foldFilter - IsNotNull, null statistics") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 1), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(IsNotNull("a")) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(IsNotNull("a")) should be (Trivial(true))
   }
 
   // Curently this filter is not supported, should always return Trivial(true)
   test("foldFilter - IsNotNull, non-null statistics") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(IsNotNull("a")) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(IsNotNull("a")) should be (Trivial(true))
   }
 
   test("foldFilter - GreaterThan, value is greater than max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(GreaterThan("a", 5)) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(GreaterThan("a", 5)) should be (Trivial(false))
   }
 
   test("foldFilter - GreaterThan, value is equal to max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(GreaterThan("a", 4)) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(GreaterThan("a", 4)) should be (Trivial(false))
   }
 
   test("foldFilter - GreaterThan, value is less than max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(GreaterThan("a", 3)) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(GreaterThan("a", 3)) should be (Trivial(true))
   }
 
   test("foldFilter - GreaterThan, value is less than min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(GreaterThan("a", 1)) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(GreaterThan("a", 1)) should be (Trivial(true))
   }
 
   test("foldFilter - GreaterThanOrEqual, value is greater than max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = GreaterThanOrEqual("a", 5)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - GreaterThanOrEqual, value is equal to max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = GreaterThanOrEqual("a", 4)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - GreaterThanOrEqual, value is less than max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = GreaterThanOrEqual("a", 3)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - GreaterThanOrEqual, value is less than min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = GreaterThanOrEqual("a", 1)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - LessThan, value is less than min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThan("a", 1)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - LessThan, value is equal to min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThan("a", 2)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - LessThan, value is greater than min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThan("a", 3)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - LessThan, value is greater than max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThan("a", 5)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - LessThanOrEqual, value is less than min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThanOrEqual("a", 1)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - LessThanOrEqual, value is equal to min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThanOrEqual("a", 2)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - LessThanOrEqual, value is greater than min") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThanOrEqual("a", 3)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - LessThanOrEqual, value is greater than max") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = parseColumns(ParquetColumnMetadata("a", 123, intStatistics(2, 4, 0), None))
     val filter = LessThanOrEqual("a", 5)
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - And(true, true)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = And(Trivial(true), Trivial(true))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - And(true, false)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = And(Trivial(true), Trivial(false))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - And(false, true)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = And(Trivial(false), Trivial(true))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - And(false, false)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = And(Trivial(false), Trivial(false))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - Or(true, true)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Or(Trivial(true), Trivial(true))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - Or(true, false)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Or(Trivial(true), Trivial(false))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - Or(false, true)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Or(Trivial(false), Trivial(true))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - Or(null, true)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Or(null, Trivial(true))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - Or(false, false)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Or(Trivial(false), Trivial(false))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 
   test("foldFilter - Not(false)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Not(Trivial(false))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(true))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(true))
   }
 
   test("foldFilter - Not(true)") {
     val conf = spark.sessionState.newHadoopConf()
     val blocks = Array.empty[ParquetBlockMetadata]
     val filter = Not(Trivial(true))
-    ParquetIndexFilters(fs, conf, blocks).foldFilter(filter) should be (Trivial(false))
+    ParquetIndexFilters(fs, blocks).foldFilter(filter) should be (Trivial(false))
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
@@ -18,18 +18,25 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import java.io.IOException
 
+import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.execution.datasources.TestMetastore
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.internal.IndexConf._
 import org.apache.spark.sql.types.StructType
 
+import com.github.lightcopy.implicits._
 import com.github.lightcopy.testutil.{SparkLocal, UnitTestSuite}
 import com.github.lightcopy.testutil.implicits._
 
 class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with TestMetastore {
-  override def beforeAll {
+  // Reset SparkSession for every test, because Metastore caches instance per session, and we
+  // do not reset options per metastore configuration.
+  before {
     startSparkSession()
   }
 
-  override def afterAll {
+  after {
     stopSparkSession()
   }
 
@@ -92,5 +99,73 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
 
   test("ParquetMetastoreSupport - inferSchema, return empty struct if no statuses provided") {
     ParquetMetastoreSupport.inferSchema(spark, Array.empty) should be (StructType(Nil))
+  }
+
+  test("invoke loadIndex without eager loading") {
+    withTempDir { dir =>
+      val options = Map(
+        METASTORE_LOCATION.key -> dir.toString / "test_metastore",
+        PARQUET_FILTER_STATISTICS_ENABLED.key -> "true",
+        PARQUET_FILTER_STATISTICS_EAGER_LOADING.key -> "false")
+      withSQLConf(options.toSeq: _*) {
+        val metastore = testMetastore(spark, options)
+        spark.range(0, 9).withColumn("str", lit("abc")).write.parquet(dir.toString / "table")
+        spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
+
+        val support = new ParquetMetastoreSupport()
+        val location = metastore.location(support.identifier, new Path(dir.toString / "table"))
+
+        val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
+          asInstanceOf[ParquetIndexCatalog]
+        catalog.indexMetadata.partitions.nonEmpty should be (true)
+        catalog.indexMetadata.partitions.foreach { partition =>
+          partition.files.nonEmpty should be (true)
+          partition.files.foreach { status =>
+            status.blocks.nonEmpty should be (true)
+            status.blocks.foreach { block =>
+              block.indexedColumns.values.foreach { metadata =>
+                metadata.filter.isDefined should be (true)
+                // none of filters should be loaded
+                metadata.filter.get.isLoaded should be (false)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("invoke loadIndex with eager loading") {
+    withTempDir { dir =>
+      val options = Map(
+        METASTORE_LOCATION.key -> dir.toString / "test_metastore",
+        PARQUET_FILTER_STATISTICS_ENABLED.key -> "true",
+        PARQUET_FILTER_STATISTICS_EAGER_LOADING.key -> "true")
+      withSQLConf(options.toSeq: _*) {
+        val metastore = testMetastore(spark, options)
+        spark.range(0, 9).withColumn("str", lit("abc")).write.parquet(dir.toString / "table")
+        spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
+
+        val support = new ParquetMetastoreSupport()
+        val location = metastore.location(support.identifier, new Path(dir.toString / "table"))
+
+        val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
+          asInstanceOf[ParquetIndexCatalog]
+        catalog.indexMetadata.partitions.nonEmpty should be (true)
+        catalog.indexMetadata.partitions.foreach { partition =>
+          partition.files.nonEmpty should be (true)
+          partition.files.foreach { status =>
+            status.blocks.nonEmpty should be (true)
+            status.blocks.foreach { block =>
+              block.indexedColumns.values.foreach { metadata =>
+                metadata.filter.isDefined should be (true)
+                // all filters should be loaded
+                metadata.filter.get.isLoaded should be (true)
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.datasources.parquet
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
+import org.apache.parquet.hadoop.metadata.BlockMetaData
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.sources._
@@ -231,6 +233,26 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
     assert(name.contains("col_a_b_c_d___e"))
   }
 
+  test("ParquetStatisticsRDD - newFilter, fail to extract statistics class") {
+    var err = intercept[RuntimeException] {
+      ParquetStatisticsRDD.newFilter("abc", null)
+    }
+    assert(err.getMessage.contains("Unsupported filter statistics type abc"))
+
+    err = intercept[RuntimeException] {
+      ParquetStatisticsRDD.newFilter(null, null)
+    }
+    assert(err.getMessage.contains("Unsupported filter statistics type null"))
+  }
+
+  test("ParquetStatisticsRDD - newFilter, select BloomFilterStatistics") {
+    val metadata = new BlockMetaData()
+    metadata.setRowCount(123L)
+    val filter = ParquetStatisticsRDD.newFilter("bloom", metadata)
+    filter.isInstanceOf[BloomFilterStatistics] should be (true)
+    filter.asInstanceOf[BloomFilterStatistics].numRows should be (123L)
+  }
+
   test("ParquetStatisticsRDD - collect statistics for empty file") {
     withTempDir { dir =>
       // all values are in single file
@@ -305,7 +327,9 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
       val status = fs.listStatus(new Path(dir.toString / "table")).
         filter(_.getPath.getName.contains("parquet"))
       val hadoopConf = spark.sessionState.newHadoopConf()
+      // enable filter statistics
       hadoopConf.set(ParquetMetastoreSupport.FILTER_DIR, dir.toString)
+      hadoopConf.set(ParquetMetastoreSupport.FILTER_TYPE, "bloom")
 
       val rdd = new ParquetStatisticsRDD(
         spark.sparkContext,

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.parquet.hadoop.metadata.BlockMetaData
@@ -355,14 +354,14 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
       assert(stats2.getNumNulls === 0)
 
       val filter1 = cols("id").filter.get
-      filter1.readData(fs, new Configuration(false))
+      filter1.readData(fs)
       filter1.mightContain("abc") should be (false)
       for (i <- 0L until 10L) {
         filter1.mightContain(i) should be (true)
       }
 
       val filter2 = cols("str").filter.get
-      filter2.readData(fs, new Configuration(false))
+      filter2.readData(fs)
       filter2.mightContain(1L) should be (false)
       filter2.mightContain(9L) should be (false)
       filter2.mightContain("abc") should be (true)

--- a/src/test/scala/org/apache/spark/sql/sources/ColumnFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/sources/ColumnFilterStatisticsSuite.scala
@@ -23,6 +23,27 @@ import com.github.lightcopy.testutil.UnitTestSuite
 import com.github.lightcopy.testutil.implicits._
 
 class ColumnFilterStatisticsSuite extends UnitTestSuite {
+  test("ColumnFilterStatistics - classForName, select BloomFilterStatistics") {
+    ColumnFilterStatistics.classForName("bloom") should be (classOf[BloomFilterStatistics])
+  }
+
+  test("ColumnFilterStatistics - classForName, throw error if name is not registered") {
+    var err = intercept[RuntimeException] {
+      ColumnFilterStatistics.classForName("BLOOM")
+    }
+    assert(err.getMessage.contains("Unsupported filter statistics type BLOOM"))
+
+    err = intercept[RuntimeException] {
+      ColumnFilterStatistics.classForName("dict")
+    }
+    assert(err.getMessage.contains("Unsupported filter statistics type dict"))
+
+    err = intercept[RuntimeException] {
+      ColumnFilterStatistics.classForName("")
+    }
+    assert(err.getMessage.contains("Unsupported filter statistics type "))
+  }
+
   test("BloomFilterStatistics - initialize") {
     val filter = BloomFilterStatistics()
     filter.getNumRows should be (1024)

--- a/src/test/scala/org/apache/spark/sql/sources/ColumnFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/sources/ColumnFilterStatisticsSuite.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.sources
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import com.github.lightcopy.testutil.UnitTestSuite
@@ -117,13 +116,14 @@ class ColumnFilterStatisticsSuite extends UnitTestSuite {
         filter.update(i)
       }
       filter.setPath(new Path(dir.toString / "filter"))
-      filter.writeData(fs, new Configuration(false))
+      filter.writeData(fs)
 
       fs.exists(filter.getPath) should be (true)
 
       val filter2 = BloomFilterStatistics()
       filter2.setPath(new Path(dir.toString / "filter"))
-      filter2.readData(fs, new Configuration(false))
+      filter2.readData(fs)
+      filter2.isLoaded should be (true)
 
       filter2.mightContain(1) should be (true)
       filter2.mightContain(1024) should be (true)
@@ -134,14 +134,14 @@ class ColumnFilterStatisticsSuite extends UnitTestSuite {
   test("BloomFilterStatistics - fail to write data for null path, do not close null stream") {
     val filter = BloomFilterStatistics()
     intercept[IllegalArgumentException] {
-      filter.writeData(fs, new Configuration(false))
+      filter.writeData(fs)
     }
   }
 
   test("BloomFilterStatistics - fail to read data for null path, do not close null stream") {
     val filter = BloomFilterStatistics()
     intercept[IllegalArgumentException] {
-      filter.readData(fs, new Configuration(false))
+      filter.readData(fs)
     }
   }
 
@@ -152,18 +152,20 @@ class ColumnFilterStatisticsSuite extends UnitTestSuite {
         filter.update(i)
       }
       filter.setPath(new Path(dir.toString / "filter"))
-      filter.writeData(fs, new Configuration(false))
+      filter.writeData(fs)
 
       val filter2 = BloomFilterStatistics()
       filter2.setPath(new Path(dir.toString / "filter"))
-      filter2.readData(fs, new Configuration(false))
+      filter2.readData(fs)
+      filter2.isLoaded should be (true)
 
       filter2.mightContain(1) should be (true)
 
       // delete path
       fs.delete(filter2.getPath, true) should be (true)
       // this call should result in no-op and use already instantiated filter
-      filter2.readData(fs, new Configuration(false))
+      filter2.readData(fs)
+      filter2.isLoaded should be (true)
       filter2.mightContain(1) should be (true)
     }
   }


### PR DESCRIPTION
This PR refactors `ParquetStatisticsRDD` for easy filter statistics addition of new types by implementing new case in `newFilter(...)` method. This results in new configuration options being introduced:
- `spark.sql.index.parquet.filter.enabled` - whether or not filter enabled, default is `false`
- `spark.sql.index.parquet.filter.type` - what type of filters to use, default is `bloom`
- `spark.sql.index.parquet.filter.eagerLoading` - whether or not load all filters when reading catalog, default is `false` which is 0.1.0 behaviour

Old option `spark.sql.index.parquet.bloom.enabled` for bloom filters does not take effect anymore, so it is recommended to switch to new options.

PR also optimises index filters resolution and statistics loading by removing dependency on `Configuration`. In case of eager loading all filter statistics (if available) are loaded asynchronously, and must fit in memory. Here are comparison of loading all filters as of 0.1.0 and new eager loading in 0.2.0:

```
scala> spark.index.parquet("temp/large.parquet")
17/01/05 12:40:46 INFO ParquetMetastoreSupport: Loading all filter statistics for catalog
17/01/05 12:40:47 INFO ParquetMetastoreSupport: Loaded all filter statistics for catalog
in 1243.407 ms
res1: org.apache.spark.sql.DataFrame = [id: bigint, col1: string ... 1 more field]
``` 

```
scala> spark.index.parquet("temp/large.parquet")
17/01/05 12:59:38 INFO ParquetMetastoreSupport: Loading all filter statistics for catalog
17/01/05 12:59:39 INFO ParquetMetastoreSupport: Loaded all filter statistics for catalog
in 399.949 ms
res1: org.apache.spark.sql.DataFrame = [id: bigint, col1: string ... 1 more field]
```