### PR TITLE
Fix issue with empty blocks

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexCatalog.scala
@@ -127,10 +127,7 @@ class ParquetIndexCatalog(
       filter: Filter,
       status: ParquetFileStatus): Filter = {
     // we need file system to resolve column filters
-    val fs = metastore.fs
-    require(status.blocks.nonEmpty,
-      "Parquet file status has empty blocks, required at least one block metadata")
-    ParquetIndexFilters(fs, status.blocks).foldFilter(filter)
+    ParquetIndexFilters(metastore.fs, status.blocks).foldFilter(filter)
   }
 
   private[parquet] def pruneIndexedPartitions(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFilters.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFilters.scala
@@ -39,8 +39,10 @@ private[parquet] case class ParquetIndexFilters(
           Trivial(true)
       }
     }
-    // all filters must be resolved at this point
-    foldFilter(references.reduceLeft(Or))
+    // If references are empty (blocks are empty) then we return Trivial(false), because only empty
+    // file has 0 block metadata chunks, and therefore there is no need to scan it.
+    // If references are non empty, join them with Or, all filters must be resolved at this point
+    if (references.isEmpty) Trivial(false) else foldFilter(references.reduceLeft(Or))
   }
 
   /**

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexCatalogSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexCatalogSuite.scala
@@ -203,17 +203,13 @@ class ParquetIndexCatalogSuite extends UnitTestSuite with SparkLocal with TestMe
     }
   }
 
-  test("resolveSupported - fail when no blocks provided") {
+  test("resolveSupported - return trivial(false) when no blocks provided") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test_metastore")
       val metadata = ParquetIndexMetadata("tablePath", StructType(Nil), StructType(Nil), null, Nil)
       val status = ParquetFileStatus(null, null, Array.empty)
       val catalog = new ParquetIndexCatalog(metastore, metadata)
-      val err = intercept[IllegalArgumentException] {
-        catalog.resolveSupported(EqualTo("a", 1), status)
-      }
-      assert(err.getMessage.contains(
-        "Parquet file status has empty blocks, required at least one block metadata"))
+      catalog.resolveSupported(EqualTo("a", 1), status) should be (Trivial(false))
     }
   }
 }


### PR DESCRIPTION
As per #40, querying table would fail, if table has empty partitions, e.g. Parquet table has empty files on disk. In this case Parquet file has 0 block metadata chunks, because there is no data. But in the code we explicitly check for `ParquetFileStatus` to have non-empty blocks, which correspond to block metadata chunks, which fails requirement for empty partitions. 

This PR fixes the problem by removing check and updating `ParquetIndexFilters` to handle empty blocks. Current approach is returning `Trivial(false)` if empty blocks are provided, because file is empty so all predicates will be evaluated to `false`.