### PR TITLE
Add dictionary filter statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ other Spark configuration or add them to `spark-defaults.conf` file.
 |------|-------------|---------|
 | `spark.sql.index.metastore` | Index metastore location, created if does not exist (`file:/folder`, `hdfs://host:port/folder`) | `./index_metastore`
 | `spark.sql.index.parquet.filter.enabled` | When set to `true`, write filter statistics for indexed columns when creating table index, otherwise only min/max statistics are used. Filter statistics are used during filtering stage, if applicable (`true`, `false`) | `true`
-| `spark.sql.index.parquet.filter.type` | When filter statistics enabled, select type of statistics to use when creating index (`bloom`) | `bloom`
+| `spark.sql.index.parquet.filter.type` | When filter statistics enabled, select type of statistics to use when creating index (`bloom`, `dict`) | `bloom`
 | `spark.sql.index.parquet.filter.eagerLoading` | When set to `true`, read and load all filter statistics in memory the first time catalog is resolved, otherwise load them lazily as needed when evaluating predicate (`true`, `false`) | `false`
 | `spark.sql.index.createIfNotExists` | When set to true, create index if one does not exist in metastore for the table, and will use all available columns for indexing (`true`, `false`) | `false`
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -34,7 +34,7 @@ import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.{SparkContext, Partition, TaskContext}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.sources.{BloomFilterStatistics, ColumnFilterStatistics, ColumnStatistics}
+import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 
 import com.github.lightcopy.util.{SerializableConfiguration, SerializableFileStatus}
@@ -281,6 +281,8 @@ private[parquet] object ParquetStatisticsRDD {
     ColumnFilterStatistics.classForName(filterType) match {
       case clazz if clazz == classOf[BloomFilterStatistics] =>
         BloomFilterStatistics(block.getRowCount)
+      case clazz if clazz == classOf[DictionaryFilterStatistics] =>
+        DictionaryFilterStatistics()
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -73,7 +73,8 @@ private[spark] object IndexConf {
 
   val PARQUET_FILTER_STATISTICS_TYPE =
     IndexConfigBuilder("spark.sql.index.parquet.filter.type").
-    doc("When filter statistics enabled, selects type of statistics to use when creating index").
+    doc("When filter statistics enabled, selects type of statistics to use when creating index. " +
+      "Available options are `bloom`, `dict`").
     stringConf.
     createWithDefault("bloom")
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDDSuite.scala
@@ -249,6 +249,13 @@ class ParquetStatisticsRDDSuite extends UnitTestSuite with SparkLocal {
     filter.asInstanceOf[BloomFilterStatistics].numRows should be (123L)
   }
 
+  test("ParquetStatisticsRDD - newFilter, select DictionaryFilterStatistics") {
+    val metadata = new BlockMetaData()
+    metadata.setRowCount(123L)
+    val filter = ParquetStatisticsRDD.newFilter("dict", metadata)
+    filter.isInstanceOf[DictionaryFilterStatistics] should be (true)
+  }
+
   test("ParquetStatisticsRDD - collect statistics for empty file") {
     withTempDir { dir =>
       // all values are in single file


### PR DESCRIPTION
This PR adds dictionary filter statistics that are based on `java.util.HashSet`. Now user can choose between `bloom` (Bloom filter statistics) and `dict` (Dictionary filter statistics) when creating index. 

Also added/updated filter statistics tests and read correctness tests.

Benchmarks on test dataset of 1,000,000 records with simple `Or(EqualTo(code,2),EqualTo(code,120))` query shows that with bloom filter statistics Spark would scan ~8 files. Same dataset with same filter and dictionary filter statistics would read only 2 files (both codes are in different files).

Dictionary filters are slower (x2) to create than bloom filters, and they take more space, stats below for sample dataset:
```
bloom filters:
total: 6.6M
metadata: 300K
filter file: 2.2K

dict filters:
total: 16M
metadata: 300K
filter file: 9.9K - 19K
```