### PR TITLE
Add preferred locations for ParquetStatisticsRDD

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexSourceStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexSourceStrategy.scala
@@ -176,7 +176,6 @@ object IndexSourceStrategy extends Strategy with Logging {
           }
 
           // Assign files to partitions using "First Fit Decreasing" (FFD)
-          // TODO: consider adding a slop factor here?
           splitFiles.foreach { file =>
             if (currentSize + file.length > maxSplitBytes) {
               closePartition()


### PR DESCRIPTION
This PR overrides preferred locations method in `ParquetStatisticsRDD` similar to `FileScanRDD` in Spark. This work is based on PR 12527. The main difference is `FileScanRDD` selects host with max bytes available, we currently do not have that logic and return all hosts in `SerializableFileStatus`.

Closes #49.