### PR TITLE
DateType and TimestampType support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Currently only these types are supported for indexed columns:
 - `IntegerType`
 - `LongType`
 - `StringType`
+- `DateType`
+- `TimestampType`
 
 ### Limitations
 - Indexed columns must be top level primitive columns with types above

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupport.scala
@@ -33,7 +33,7 @@ import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
 // top level.
 
 abstract class Container {
-  def setString(ordinal: Int, value: String): Unit
+  def setBinary(ordinal: Int, value: Binary): Unit
   def setBoolean(ordinal: Int, value: Boolean): Unit
   def setDouble(ordinal: Int, value: Double): Unit
   def setInt(ordinal: Int, value: Int): Unit
@@ -47,7 +47,7 @@ private[parquet] class MapContainer extends Container {
   // buffer to store values in container, column index - value
   private var buffer: JHashMap[Int, Any] = null
 
-  override def setString(ordinal: Int, value: String): Unit = buffer.put(ordinal, value)
+  override def setBinary(ordinal: Int, value: Binary): Unit = buffer.put(ordinal, value)
   override def setBoolean(ordinal: Int, value: Boolean): Unit = buffer.put(ordinal, value)
   override def setDouble(ordinal: Int, value: Double): Unit = buffer.put(ordinal, value)
   override def setInt(ordinal: Int, value: Int): Unit = buffer.put(ordinal, value)
@@ -76,7 +76,7 @@ class ParquetIndexPrimitiveConverter(
     val updater: Container)
   extends PrimitiveConverter {
 
-  override def addBinary(value: Binary): Unit = updater.setString(ordinal, value.toStringUsingUTF8)
+  override def addBinary(value: Binary): Unit = updater.setBinary(ordinal, value)
   override def addBoolean(value: Boolean): Unit = updater.setBoolean(ordinal, value)
   override def addDouble(value: Double): Unit = updater.setDouble(ordinal, value)
   override def addInt(value: Int): Unit = updater.setInt(ordinal, value)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.types._
  */
 object ParquetSchemaUtils {
   // Supported top-level Spark SQL data types
-  val SUPPORTED_TYPES: Set[DataType] = Set(IntegerType, LongType, StringType)
+  val SUPPORTED_TYPES: Set[DataType] =
+    Set(IntegerType, LongType, StringType, DateType, TimestampType)
 
   /**
    * Validate input schema as `StructType` and throw exception if schema does not match expected

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -100,10 +100,10 @@ class ParquetStatisticsRDD(
     // convert schema of struct type into Parquet schema
     val indexSchema: MessageType = new ParquetSchemaConverter().convert(schema)
     logDebug(s"""
-      | == Indexed schema ==
-      | ${schema.simpleString}
-      | == Converted Parquet schema ==
-      | $indexSchema
+      |== Indexed schema ==
+      |${schema.simpleString}
+      |== Converted Parquet schema ==
+      |$indexSchema
       """.stripMargin)
     // resolve filter directory as root for all column filter statistics. If path is defined,
     // then use it to store serialized filter data, otherwise it is assumed that filter

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -175,7 +175,7 @@ class ParquetStatisticsRDD(
           attemptContext.getConfiguration.set(ParquetMetastoreSupport.READ_SCHEMA,
             indexSchema.toString)
 
-          val reader = new ParquetRecordReader[Container](new ParquetIndexReadSupport())
+          val reader = new ParquetRecordReader[RecordContainer](new ParquetIndexReadSupport())
           try {
             reader.initialize(parquetSplit, attemptContext)
             // current block index, when row count > record count we select next block

--- a/src/main/scala/org/apache/spark/sql/sources/ColumnStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/sources/ColumnStatistics.scala
@@ -81,11 +81,11 @@ abstract class ColumnStatistics extends Serializable {
   /**
    * Update statistics with non-null value, min and max should be updated according to column type,
    * e.g. sorting of bytes for strings, etc. It is guaranteed that method will be called for
-   * defined value. If type does not match defaults to no-op.
+   * defined value. If type does not match, exception is thrown.
    */
   def updateMinMax(value: Any): Unit = {
     updateMinMaxFunc.applyOrElse[Any, Unit](value, { case other =>
-      // type mismatch, default to no-op
+      throw new IllegalArgumentException(s"$this does not support value $other for update")
     })
   }
 

--- a/src/main/scala/org/apache/spark/sql/sources/ColumnStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/sources/ColumnStatistics.scala
@@ -16,10 +16,6 @@
 
 package org.apache.spark.sql.sources
 
-import java.nio.ByteOrder
-
-import org.apache.parquet.io.api.Binary
-
 import org.apache.spark.sql.types._
 
 /**
@@ -265,23 +261,16 @@ case class StringColumnStatistics() extends ColumnStatistics {
   private var max: String = null
   private var isSet: Boolean = false
 
-  private def setMinMaxString(strValue: String): Unit = {
-    if (!isSet) {
-      min = strValue
-      max = strValue
-      isSet = true
-    } else {
-      if (min > strValue) min = strValue
-      if (max < strValue) max = strValue
-    }
-  }
-
   override protected def updateMinMaxFunc: PartialFunction[Any, Unit] = {
-    case binValue: Binary => {
-      setMinMaxString(binValue.toStringUsingUTF8)
-    }
     case strValue: String => {
-      setMinMaxString(strValue)
+      if (!isSet) {
+        min = strValue
+        max = strValue
+        isSet = true
+      } else {
+        if (min > strValue) min = strValue
+        if (max < strValue) max = strValue
+      }
     }
   }
 
@@ -312,33 +301,23 @@ case class StringColumnStatistics() extends ColumnStatistics {
 
 /**
  * [[DateColumnStatistics]] keep track of min/max/nulls for Date column, which is a Parquet int32
- * field. Note that when we update min/max from Parquet values, we also process integer value,
- * but actual checks on contains or/and greater/less/equals are for java.sql.Date only.
+ * field, but converted into java.sql.Date instance in record container.
  */
 case class DateColumnStatistics() extends ColumnStatistics {
   private var min: java.sql.Date = null
   private var max: java.sql.Date = null
   private var isSet: Boolean = false
 
-  /** Set min and max date values based on value provided */
-  private def setMinMaxDate(dateValue: java.sql.Date): Unit = {
-    if (!isSet) {
-      min = dateValue
-      max = dateValue
-      isSet = true
-    } else {
-      if (min.after(dateValue)) min = dateValue
-      if (max.before(dateValue)) max = dateValue
-    }
-  }
-
-  // When reading Parquet file values are stored as int32, so we process them as sql dates
   override protected def updateMinMaxFunc: PartialFunction[Any, Unit] = {
-    case intValue: Int => {
-      setMinMaxDate(new java.sql.Date(intValue.toLong))
-    }
     case dateValue: java.sql.Date => {
-      setMinMaxDate(dateValue)
+      if (!isSet) {
+        min = dateValue
+        max = dateValue
+        isSet = true
+      } else {
+        if (min.after(dateValue)) min = dateValue
+        if (max.before(dateValue)) max = dateValue
+      }
     }
   }
 
@@ -372,52 +351,25 @@ case class DateColumnStatistics() extends ColumnStatistics {
 
 /**
  * [[TimestampColumnStatistics]] keep track of min/max/nulls for timestamp column, which is int96
- * in Parquet, but passed into statistics as Binary value. See `ParquetRowConverter` in Spark for
+ * in Parquet, but passed into statistics as java.sql.Timestamp value. See `RecordContainer` for
  * more information.
  */
 case class TimestampColumnStatistics() extends ColumnStatistics {
-  final val JULIAN_DAY_OF_EPOCH = 2440588
-  final val SECONDS_PER_DAY = 60 * 60 * 24L
-  final val MICROS_PER_SECOND = 1000L * 1000L
-
   private var min: java.sql.Timestamp = null
   private var max: java.sql.Timestamp = null
   private var isSet: Boolean = false
 
-  /** Set min and max timetamp values based on value provided */
-  private def setMinMaxTimestamp(timeValue: java.sql.Timestamp): Unit = {
-    if (!isSet) {
-      min = timeValue
-      max = timeValue
-      isSet = true
-    } else {
-      if (min.after(timeValue)) min = timeValue
-      if (max.before(timeValue)) max = timeValue
-    }
-  }
-
-  /**
-   * Returns the number of microseconds since epoch from Julian day
-   * and nanoseconds in a day
-   */
-  private def fromJulianDay(day: Int, nanoseconds: Long): Long = {
-    // use Long to avoid rounding errors
-    val seconds = (day - JULIAN_DAY_OF_EPOCH).toLong * SECONDS_PER_DAY
-    seconds * MICROS_PER_SECOND + nanoseconds / 1000L
-  }
-
   // When reading Parquet file values are stored as int96, which returned by container as Binary
   override protected def updateMinMaxFunc: PartialFunction[Any, Unit] = {
-    case binValue: Binary => {
-      assert(binValue.length() == 12, "Timestamps (with nanoseconds) are expected to be stored " +
-        s"in 12-byte long binaries, but got a ${binValue.length()}-byte binary")
-      val buf = binValue.toByteBuffer.order(ByteOrder.LITTLE_ENDIAN)
-      val timeOfDayNanos = buf.getLong
-      val julianDay = buf.getInt
-      setMinMaxTimestamp(new java.sql.Timestamp(fromJulianDay(julianDay, timeOfDayNanos)))
-    }
     case timeValue: java.sql.Timestamp => {
-      setMinMaxTimestamp(timeValue)
+      if (!isSet) {
+        min = timeValue
+        max = timeValue
+        isSet = true
+      } else {
+        if (min.after(timeValue)) min = timeValue
+        if (max.before(timeValue)) max = timeValue
+      }
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -367,12 +367,12 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         import sqlContext.implicits._
         val df = Seq(
           (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
-          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
-          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "def", 2),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "ghi", 3)
         ).toDF("col1", "col2", "col3", "col4")
         df.write.parquet(dir.toString / "test")
 
-        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        spark.index.create.indexBy("col1", "col2").parquet(dir.toString / "test")
         val df1 = spark.index.parquet(dir.toString / "test").filter(
           col("col1") === new java.sql.Date(300000000L) ||
           col("col2") === new java.sql.Timestamp(330000000000L))
@@ -394,12 +394,12 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         import sqlContext.implicits._
         val df = Seq(
           (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
-          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
-          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "def", 2),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "ghi", 3)
         ).toDF("col1", "col2", "col3", "col4")
         df.write.parquet(dir.toString / "test")
 
-        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        spark.index.create.indexBy("col1", "col2").parquet(dir.toString / "test")
         val df1 = spark.index.parquet(dir.toString / "test").filter(
           col("col1") > new java.sql.Date(300000000L) &&
           col("col2") >= new java.sql.Timestamp(330000000000L))
@@ -551,12 +551,12 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         import sqlContext.implicits._
         val df = Seq(
           (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
-          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
-          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "def", 2),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "ghi", 3)
         ).toDF("col1", "col2", "col3", "col4")
         df.write.parquet(dir.toString / "test")
 
-        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        spark.index.create.indexBy("col1", "col2").parquet(dir.toString / "test")
         val df1 = spark.index.parquet(dir.toString / "test").filter(
           col("col1") === new java.sql.Date(300000000L) ||
           col("col2") === new java.sql.Timestamp(330000000000L))
@@ -578,12 +578,12 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         import sqlContext.implicits._
         val df = Seq(
           (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
-          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
-          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "def", 2),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "ghi", 3)
         ).toDF("col1", "col2", "col3", "col4")
         df.write.parquet(dir.toString / "test")
 
-        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        spark.index.create.indexBy("col1", "col2").parquet(dir.toString / "test")
         val df1 = spark.index.parquet(dir.toString / "test").filter(
           col("col1") > new java.sql.Date(300000000L) &&
           col("col2") >= new java.sql.Timestamp(330000000000L))

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -357,6 +357,60 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
     }
   }
 
+  test("[bloom] read correctness for Parquet table with Date/Timestamp Eq filter") {
+    withTempDir { dir =>
+      withSQLConf(
+          METASTORE_LOCATION.key -> dir.toString / "metastore",
+          PARQUET_FILTER_STATISTICS_ENABLED.key -> "true",
+          PARQUET_FILTER_STATISTICS_TYPE.key -> "bloom") {
+        val sqlContext = spark.sqlContext
+        import sqlContext.implicits._
+        val df = Seq(
+          (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+        ).toDF("col1", "col2", "col3", "col4")
+        df.write.parquet(dir.toString / "test")
+
+        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        val df1 = spark.index.parquet(dir.toString / "test").filter(
+          col("col1") === new java.sql.Date(300000000L) ||
+          col("col2") === new java.sql.Timestamp(330000000000L))
+        val df2 = spark.read.parquet(dir.toString / "test").filter(
+          col("col1") === new java.sql.Date(300000000L) ||
+          col("col2") === new java.sql.Timestamp(330000000000L))
+        checkAnswer(df1, df2)
+      }
+    }
+  }
+
+  test("[bloom] read correctness for Parquet table with Date/Timestamp GreaterThan filter") {
+    withTempDir { dir =>
+      withSQLConf(
+          METASTORE_LOCATION.key -> dir.toString / "metastore",
+          PARQUET_FILTER_STATISTICS_ENABLED.key -> "true",
+          PARQUET_FILTER_STATISTICS_TYPE.key -> "bloom") {
+        val sqlContext = spark.sqlContext
+        import sqlContext.implicits._
+        val df = Seq(
+          (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+        ).toDF("col1", "col2", "col3", "col4")
+        df.write.parquet(dir.toString / "test")
+
+        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        val df1 = spark.index.parquet(dir.toString / "test").filter(
+          col("col1") > new java.sql.Date(300000000L) &&
+          col("col2") >= new java.sql.Timestamp(330000000000L))
+        val df2 = spark.read.parquet(dir.toString / "test").filter(
+          col("col1") > new java.sql.Date(300000000L) &&
+          col("col2") >= new java.sql.Timestamp(330000000000L))
+        checkAnswer(df1, df2)
+      }
+    }
+  }
+
   //////////////////////////////////////////////////////////////
   // Read correctness with Dictionary filter statistics
   //////////////////////////////////////////////////////////////
@@ -482,6 +536,60 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
           filter(col("id") > 900 || col("id") < 2)
         val df2 = spark.read.parquet(dir.toString / "test").
           filter(col("id") > 900 || col("id") < 2)
+        checkAnswer(df1, df2)
+      }
+    }
+  }
+
+  test("[dictionary] read correctness for Parquet table with Date/Timestamp Eq filter") {
+    withTempDir { dir =>
+      withSQLConf(
+          METASTORE_LOCATION.key -> dir.toString / "metastore",
+          PARQUET_FILTER_STATISTICS_ENABLED.key -> "true",
+          PARQUET_FILTER_STATISTICS_TYPE.key -> "dict") {
+        val sqlContext = spark.sqlContext
+        import sqlContext.implicits._
+        val df = Seq(
+          (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+        ).toDF("col1", "col2", "col3", "col4")
+        df.write.parquet(dir.toString / "test")
+
+        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        val df1 = spark.index.parquet(dir.toString / "test").filter(
+          col("col1") === new java.sql.Date(300000000L) ||
+          col("col2") === new java.sql.Timestamp(330000000000L))
+        val df2 = spark.read.parquet(dir.toString / "test").filter(
+          col("col1") === new java.sql.Date(300000000L) ||
+          col("col2") === new java.sql.Timestamp(330000000000L))
+        checkAnswer(df1, df2)
+      }
+    }
+  }
+
+  test("[dictionary] read correctness for Parquet table with Date/Timestamp GreaterThan filter") {
+    withTempDir { dir =>
+      withSQLConf(
+          METASTORE_LOCATION.key -> dir.toString / "metastore",
+          PARQUET_FILTER_STATISTICS_ENABLED.key -> "true",
+          PARQUET_FILTER_STATISTICS_TYPE.key -> "dict") {
+        val sqlContext = spark.sqlContext
+        import sqlContext.implicits._
+        val df = Seq(
+          (new java.sql.Date(200000000L), new java.sql.Timestamp(110000000000L), "abc", 1),
+          (new java.sql.Date(300000000L), new java.sql.Timestamp(220000000000L), "abc", 1),
+          (new java.sql.Date(400000000L), new java.sql.Timestamp(330000000000L), "abc", 1)
+        ).toDF("col1", "col2", "col3", "col4")
+        df.write.parquet(dir.toString / "test")
+
+        spark.index.create.indexBy("col1").parquet(dir.toString / "test")
+        val df1 = spark.index.parquet(dir.toString / "test").filter(
+          col("col1") > new java.sql.Date(300000000L) &&
+          col("col2") >= new java.sql.Timestamp(330000000000L))
+        val df2 = spark.read.parquet(dir.toString / "test").filter(
+          col("col1") > new java.sql.Date(300000000L) &&
+          col("col2") >= new java.sql.Timestamp(330000000000L))
         checkAnswer(df1, df2)
       }
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupportSuite.scala
@@ -93,6 +93,16 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
     container.getByIndex(0).isInstanceOf[java.sql.Date] should be (true)
   }
 
+  test("BufferRecordContainer - fail to parse Integer with unsupported Primitive Type") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    val err = intercept[IllegalArgumentException] {
+      container.setParquetInteger(0, new PrimitiveType(REQUIRED, INT64, "a"), 1)
+    }
+    assert(err.getMessage.contains(
+      "Field required int64 a with value 1 at position 0 cannot be parsed as Parquet Integer"))
+  }
+
   test("BufferRecordContainer - set Parquet Integer type as Int") {
     val container = new BufferRecordContainer()
     container.init(numFields = 1)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupportSuite.scala
@@ -18,46 +18,145 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.parquet.io.api.Binary
 import org.apache.parquet.schema._
+import org.apache.parquet.schema.OriginalType._
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName._
 import org.apache.parquet.schema.Type.Repetition._
+
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
 import com.github.lightcopy.testutil.UnitTestSuite
 import com.github.lightcopy.testutil.implicits._
 
 class ParquetIndexReadSupportSuite extends UnitTestSuite {
-  test("MapContainer - init") {
-    val container = new MapContainer()
-    container.init()
-    container.toString should be ("MapContainer(buffer={})")
+  test("BufferRecordContainer - init") {
+    val container = new BufferRecordContainer()
+    container.toString should be ("BufferRecordContainer(buffer=null)")
+    container.init(numFields = 2)
+    container.toString should be ("BufferRecordContainer(buffer=[null, null])")
   }
 
-  test("MapContainer - clear map with init") {
-    val container = new MapContainer()
-    container.init()
+  test("BufferRecordContainer - clear buffer with init") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
     container.setString(0, "str")
-    container.init()
-    container.toString should be ("MapContainer(buffer={})")
+    container.init(numFields = 1)
+    container.toString should be ("BufferRecordContainer(buffer=[null])")
   }
 
-  test("MapContainer - set all ordinals") {
-    val container = new MapContainer()
-    container.init()
+  test("BufferRecordContainer - reset empty buffer with different numFields") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.toString should be ("BufferRecordContainer(buffer=[null])")
+    container.init(numFields = 2)
+    container.toString should be ("BufferRecordContainer(buffer=[null, null])")
+  }
+
+  test("BufferRecordContainer - reset filled buffer with different numFields") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.setInt(0, 5)
+    container.toString should be ("BufferRecordContainer(buffer=[5])")
+    container.init(numFields = 2)
+    container.toString should be ("BufferRecordContainer(buffer=[null, null])")
+  }
+
+  test("BufferRecordContainer - reset filled buffer with same numFields") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 2)
+    container.setInt(0, 5)
+    container.setString(1, "a")
+    container.toString should be ("BufferRecordContainer(buffer=[5, a])")
+    container.init(numFields = 2)
+    container.toString should be ("BufferRecordContainer(buffer=[null, null])")
+  }
+
+  test("BufferRecordContainer - set Parquet Binary type as Timestamp") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"),
+      Binary.fromByteArray(new Array[Byte](12), 0, 12))
+    container.getByIndex(0).isInstanceOf[java.sql.Timestamp] should be (true)
+  }
+
+  test("BufferRecordContainer - set Parquet Binary type as String") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.setParquetBinary(0, new PrimitiveType(REQUIRED, BINARY, "a"),
+      Binary.fromString("a"))
+    container.getByIndex(0).isInstanceOf[String] should be (true)
+  }
+
+  test("BufferRecordContainer - set Parquet Integer type as Date") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.setParquetInteger(0, new PrimitiveType(REQUIRED, INT32, "a", DATE), 1)
+    container.getByIndex(0).isInstanceOf[java.sql.Date] should be (true)
+  }
+
+  test("BufferRecordContainer - set Parquet Integer type as Int") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.setParquetInteger(0, new PrimitiveType(REQUIRED, INT32, "a"), 1)
+    container.getByIndex(0).isInstanceOf[Int] should be (true)
+  }
+
+  test("BufferRecordContainer - parse java.sql.Date value") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    container.setParquetInteger(0, new PrimitiveType(REQUIRED, INT32, "a", DATE), 1)
+    container.getByIndex(0) should be (DateTimeUtils.toJavaDate(1))
+  }
+
+  test("BufferRecordContainer - fail to parse byte array as java.sql.Timestamp") {
+    val arr = new Array[Byte](14)
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    var err = intercept[AssertionError] {
+      val bin = Binary.fromByteArray(arr, 0, 11)
+      container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"), bin)
+    }
+    assert(err.getMessage.contains(
+      "Timestamps (with nanoseconds) are expected to be stored in 12-byte long binaries"))
+
+    err = intercept[AssertionError] {
+      val bin = Binary.fromByteArray(arr, 0, 13)
+      container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"), bin)
+    }
+  }
+
+  test("BufferRecordContainer - parse byte array as java.sql.Timestamp") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
+    // same as 110000000000L or 1970-01-02 18:33:20.0
+    val arr = Array[Byte](0, -32, -99, -51, 118, 21, 0, 0, -115, 61, 37, 0)
+    val bin = Binary.fromByteArray(arr, 0, arr.length)
+    container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"), bin)
+    container.getByIndex(0) should be (DateTimeUtils.toJavaTimestamp(110000000000L))
+  }
+
+  test("BufferRecordContainer - set all ordinals") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 7)
     container.setString(0, "str")
     container.setBoolean(1, true)
     container.setDouble(2, 0.2)
     container.setInt(3, 5)
     container.setLong(4, 7L)
+    container.setDate(5, new java.sql.Date(1L))
+    container.setTimestamp(6, new java.sql.Timestamp(1L))
 
     assert(container.getByIndex(0) === "str")
     assert(container.getByIndex(1) === true)
     assert(container.getByIndex(2) === 0.2)
     assert(container.getByIndex(3) === 5)
     assert(container.getByIndex(4) === 7L)
+    assert(container.getByIndex(5) === new java.sql.Date(1L))
+    assert(container.getByIndex(6) === new java.sql.Timestamp(1L))
   }
 
-  test("MapContainer - overwrite value for ordinal") {
-    val container = new MapContainer()
-    container.init()
+  test("BufferRecordContainer - overwrite value for ordinal") {
+    val container = new BufferRecordContainer()
+    container.init(numFields = 1)
     container.setString(0, "str")
     container.setInt(0, 123)
 
@@ -65,13 +164,18 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
   }
 
   test("ParquetIndexPrimitiveConverter - add fields") {
-    val container = new MapContainer()
-    container.init()
-    val c1 = new ParquetIndexPrimitiveConverter(0, container)
-    val c2 = new ParquetIndexPrimitiveConverter(1, container)
-    val c3 = new ParquetIndexPrimitiveConverter(2, container)
-    val c4 = new ParquetIndexPrimitiveConverter(3, container)
-    val c5 = new ParquetIndexPrimitiveConverter(4, container)
+    val container = new BufferRecordContainer()
+    container.init(numFields = 5)
+    val c1 = new ParquetIndexPrimitiveConverter(0,
+      new PrimitiveType(REQUIRED, BINARY, "a"), container)
+    val c2 = new ParquetIndexPrimitiveConverter(1,
+      new PrimitiveType(REQUIRED, BOOLEAN, "a"), container)
+    val c3 = new ParquetIndexPrimitiveConverter(2,
+      new PrimitiveType(REQUIRED, DOUBLE, "a"), container)
+    val c4 = new ParquetIndexPrimitiveConverter(3,
+      new PrimitiveType(REQUIRED, INT32, "a"), container)
+    val c5 = new ParquetIndexPrimitiveConverter(4,
+      new PrimitiveType(REQUIRED, INT64, "a"), container)
 
     c1.addBinary(Binary.fromString("abc"))
     c2.addBoolean(true)
@@ -87,7 +191,7 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
   }
 
   test("ParquetIndexGroupConverter - prepare converters") {
-    val container = new MapContainer()
+    val container = new BufferRecordContainer()
     val schema = new MessageType("root1",
       new PrimitiveType(REQUIRED, INT64, "a"),
       new PrimitiveType(OPTIONAL, BINARY, "b")).asGroupType
@@ -99,7 +203,7 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
   }
 
   test("ParquetIndexGroupConverter - fail if type is not primitive") {
-    val container = new MapContainer()
+    val container = new BufferRecordContainer()
     val schema = new MessageType("root1",
       new PrimitiveType(REQUIRED, INT64, "a"),
       new PrimitiveType(REQUIRED, BINARY, "b"),

--- a/src/test/scala/org/apache/spark/sql/sources/ColumnFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/sources/ColumnFilterStatisticsSuite.scala
@@ -112,6 +112,14 @@ class ColumnFilterStatisticsSuite extends UnitTestSuite {
     filter.mightContain(1024L) should be (true)
   }
 
+  test("BloomFilterStatistics - supported types") {
+    for (i <- Seq(1, 1L, "abc", new java.sql.Date(1L), new java.sql.Timestamp(1L))) {
+      val filter = BloomFilterStatistics()
+      filter.update(i)
+      filter.mightContain(i) should be (true)
+    }
+  }
+
   test("BloomFilterStatistics - unsupported types") {
     val filter = BloomFilterStatistics()
     // boolean is not supported by bloom filter
@@ -230,6 +238,14 @@ class ColumnFilterStatisticsSuite extends UnitTestSuite {
     filter.mightContain("abc") should be (false)
     filter.mightContain(true) should be (false)
     filter.mightContain(1024L) should be (false)
+  }
+
+  test("DictionaryFilterStatistics - supported types") {
+    for (i <- Seq(1, 1L, "abc", new java.sql.Date(1L), new java.sql.Timestamp(1L))) {
+      val filter = DictionaryFilterStatistics()
+      filter.update(i)
+      filter.mightContain(i) should be (true)
+    }
   }
 
   test("DictionaryFilterStatistics - mightContain on empty filter") {

--- a/src/test/scala/org/apache/spark/sql/sources/ColumnStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/sources/ColumnStatisticsSuite.scala
@@ -868,7 +868,8 @@ class ColumnStatisticsSuite extends UnitTestSuite {
 
     stats.updateMinMax(new SQLDate(1L))
     stats.incrementNumNulls()
-    stats.toString should be ("DateColumnStatistics[min=1970-01-01, max=1970-01-01, nulls=1]")
+    val expected = s"DateColumnStatistics[min=${new SQLDate(1L)}, max=${new SQLDate(1L)}, nulls=1]"
+    stats.toString should be (expected)
   }
 
   test("DateColumnStatistics - contains") {
@@ -1109,8 +1110,8 @@ class ColumnStatisticsSuite extends UnitTestSuite {
 
     stats.updateMinMax(new SQLTimestamp(1L))
     stats.incrementNumNulls()
-    val expected = "TimestampColumnStatistics[min=1970-01-01 12:00:00.001, " +
-      "max=1970-01-01 12:00:00.001, nulls=1]"
+    val expected = "TimestampColumnStatistics" +
+      s"[min=${new SQLTimestamp(1L)}, max=${new SQLTimestamp(1L)}, nulls=1]"
     stats.toString should be (expected)
   }
 


### PR DESCRIPTION
This PR adds support for `DateType` and `TimestampType` SQL column types by adding new statistics types and updating filter statistics to handle `java.sql.Date` and `java.sql.Timestamp`. 

Also update behaviour of processing values of unmatched type for column statistics. Before this patch, those values were ignored, after - exception will be thrown.