### PR TITLE
Extract metadata when inferring schema

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -33,7 +33,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
 
 import com.github.lightcopy.util.{SerializableFileStatus, IOUtils}
 
@@ -216,18 +216,24 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
   }
 }
 
-object ParquetMetastoreSupport {
+object ParquetMetastoreSupport extends Logging {
   // internal Hadoop configuration option to set schema for Parquet reader
   private[sql] val READ_SCHEMA = "spark.sql.hadoop.index.parquet.read.schema"
   // internal Hadoop configuration option to specify filter directory
   private[sql] val FILTER_DIR = "spark.sql.hadoop.index.parquet.filter.dir"
   // internal Hadoop configuration option to specify filter name/type
   private[sql] val FILTER_TYPE = "spark.sql.hadoop.index.parquet.filter.type"
+  // internal footer metadata key for Spark SQL schema
+  private[sql] val SPARK_METADATA_KEY = "org.apache.spark.sql.parquet.row.metadata"
   // metadata name
   val TABLE_METADATA = "_table_metadata"
 
-  /** Partition columns are automatically added when reading file format */
+  /**
+   * Infer schema from collected statistics.
+   * Partition columns are automatically added when reading file format
+   */
   def inferSchema(sparkSession: SparkSession, statistics: Array[ParquetFileStatus]): StructType = {
+    // create converter to fall back to Parquet schema parsing
     val assumeBinaryIsString = sparkSession.sessionState.conf.isParquetBinaryAsString
     val assumeInt96IsTimestamp = sparkSession.sessionState.conf.isParquetINT96AsTimestamp
     val writeLegacyParquetFormat = sparkSession.sessionState.conf.writeLegacyParquetFormat
@@ -236,14 +242,30 @@ object ParquetMetastoreSupport {
       assumeInt96IsTimestamp = assumeInt96IsTimestamp,
       writeLegacyParquetFormat = writeLegacyParquetFormat)
 
-    if (statistics.isEmpty) {
-      StructType(Seq.empty)
-    } else {
-      val schema = converter.convert(MessageTypeParser.parseMessageType(statistics.head.fileSchema))
-      statistics.tail.foreach { stats =>
-        schema.merge(converter.convert(MessageTypeParser.parseMessageType(stats.fileSchema)))
-      }
-      schema
+    // util to convert Parquet schema into Spark SQL schema using global converter
+    def parquetToStructType(parquetSchema: String): StructType = {
+      converter.convert(MessageTypeParser.parseMessageType(parquetSchema))
     }
+
+    // Parse Spark SQL schema, if found, otherwise fall back to the Parquet schema
+    val schemas: Array[StructType] = statistics.map { status =>
+      val parquetSchema = status.fileSchema
+      status.sqlSchema match {
+        case Some(serializedSchema) =>
+          try {
+            DataType.fromJson(serializedSchema).asInstanceOf[StructType]
+          } catch {
+            case NonFatal(err) =>
+              logWarning(s"Failed to parse Spark SQL serialized schema $serializedSchema, " +
+                s"reason: $err. Using Parquet file schema")
+              parquetToStructType(status.fileSchema)
+          }
+        case None =>
+          parquetToStructType(status.fileSchema)
+      }
+    }
+
+    // Merge into final schema
+    schemas.reduceOption { (left, right) => left.merge(right) }.getOrElse(StructType(Nil))
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.execution.datasources.parquet
 import java.io.IOException
 import java.util.Arrays
 
-import scala.util.control.NonFatal
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext
+import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -266,6 +266,8 @@ object ParquetMetastoreSupport extends Logging {
     }
 
     // Merge into final schema
-    schemas.reduceOption { (left, right) => left.merge(right) }.getOrElse(StructType(Nil))
+    schemas.reduceOption { (left, right) =>
+      ParquetSchemaUtils.merge(left, right)
+    }.getOrElse(StructType(Nil))
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
@@ -84,4 +84,8 @@ object ParquetSchemaUtils {
       (field.getName, index)
     }
   }
+
+  def merge(schema1: StructType, schema2: StructType): StructType = {
+    schema1.merge(schema2)
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.Try
 
 import org.apache.parquet.schema.MessageType
 
@@ -85,7 +86,40 @@ object ParquetSchemaUtils {
     }
   }
 
+  /** Update field with provided metadata, performs replacement, not merge */
+  private def withMetadata(field: StructField, metadata: Metadata): StructField = {
+    StructField(field.name, field.dataType, field.nullable, metadata)
+  }
+
+  /**
+   * Merge schemas with preserved metadata for top-level fields.
+   * TODO: implement merge for nested types.
+   */
   def merge(schema1: StructType, schema2: StructType): StructType = {
-    schema1.merge(schema2)
+    // perform field merge, this does not merge metadata
+    val mergedSchema = schema1.merge(schema2)
+
+    // update field with extracted and merged metadata
+    val updatedFields = mergedSchema.map { field =>
+      val field1 = Try(schema1(field.name)).toOption
+      val field2 = Try(schema2(field.name)).toOption
+
+      (field1, field2) match {
+        case (Some(value1), Some(value2)) =>
+          val metadata = new MetadataBuilder().
+            withMetadata(value1.metadata).
+            withMetadata(value2.metadata).build
+          if (metadata == field.metadata) field else withMetadata(field, metadata)
+        case (Some(value1), None) =>
+          if (value1 == field) field else withMetadata(field, value1.metadata)
+        case (None, Some(value2)) =>
+          if (value2 == field) field else withMetadata(field, value2.metadata)
+        case other =>
+          field
+      }
+    }
+
+    // return final merged schema
+    StructType(updatedFields)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetStatisticsRDD.scala
@@ -165,6 +165,8 @@ class ParquetStatisticsRDD(
         // read metadata from the file footer
         val metadata = ParquetFileReader.readFooter(configuration, parquetStatus, NO_FILTER)
         val fileSchema = metadata.getFileMetaData.getSchema
+        val sqlSchema = metadata.getFileMetaData.getKeyValueMetaData.asScala.
+          get(ParquetMetastoreSupport.SPARK_METADATA_KEY)
         // check that requested schema is part of the file schema
         fileSchema.checkContains(indexSchema)
         // extract unique map of top level columns
@@ -263,7 +265,7 @@ class ParquetStatisticsRDD(
         // currently global Parquet schema is merged and inferred on a driver, which is suboptimal
         // since we can reduce schema during metadata collection.
         // TODO: Partially merge schema during each task
-        ParquetFileStatus(serdeStatus, fileSchema.toString, blockMetadata)
+        ParquetFileStatus(serdeStatus, fileSchema.toString, blockMetadata, sqlSchema = sqlSchema)
       }
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/metadata.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/metadata.scala
@@ -50,11 +50,15 @@ case class ParquetBlockMetadata(
     rowCount: Long,
     indexedColumns: Map[String, ParquetColumnMetadata])
 
-/** Extended Parquet file status to preserve schema and file status */
+/**
+ * Extended Parquet file status to preserve schema and file status. Also allows to set Spark SQL
+ * metadata from Parquet schema as `sqlSchema`.
+ */
 case class ParquetFileStatus(
     status: SerializableFileStatus,
     fileSchema: String,
-    blocks: Array[ParquetBlockMetadata]) {
+    blocks: Array[ParquetBlockMetadata],
+    sqlSchema: Option[String] = None) {
   def numRows(): Long = {
     if (blocks.isEmpty) 0 else blocks.map { _.rowCount }.sum
   }


### PR DESCRIPTION
This PR fixes bug when merging Parquet schema, it would leave field metadata out, which results in inconsistency in schema between `spark.read.parquet` and `spark.index.parquet`. This issue was found when trying to index persistent tables. 

The implementation is slightly different from Spark. Instead of just fetching the first SQL schema from footer metadata, we parse all of them and try to merge `StructType`s including metadata.