### PR TITLE
Persistent table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Spark SQL index for Parquet tables
 [![Join the chat at https://gitter.im/lightcopy/parquet-index](https://badges.gitter.im/lightcopy/parquet-index.svg)](https://gitter.im/lightcopy/parquet-index?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Overview
-Package allows to create index for Parquet tables (as [datasource](Example) and
-[persistent tables](Persistent tables API)) to reduce query latency when used for
+Package allows to create index for Parquet tables (as [datasource](#example) and
+[persistent tables](#persistent-tables-api)) to reduce query latency when used for
 _almost interactive_ analysis or point queries in Spark SQL. It is designed for use case when table
 does not change frequently, but is used for queries often, e.g. using Thrift JDBC/ODBC server. When
 indexed, schema and list of files (including partitioning) will be automatically resolved from index

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Spark SQL index for Parquet tables
 [![Join the chat at https://gitter.im/lightcopy/parquet-index](https://badges.gitter.im/lightcopy/parquet-index.svg)](https://gitter.im/lightcopy/parquet-index?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Overview
-Package allows to create index for Parquet tables to reduce query latency when used for
+Package allows to create index for Parquet tables (as [datasource](Example) and
+[persistent tables](Persistent tables API)) to reduce query latency when used for
 _almost interactive_ analysis or point queries in Spark SQL. It is designed for use case when table
 does not change frequently, but is used for queries often, e.g. using Thrift JDBC/ODBC server. When
 indexed, schema and list of files (including partitioning) will be automatically resolved from index
@@ -191,6 +192,49 @@ df = context.index.parquet('table.parquet').filter('col1 = 123')
 
 # Delete index from metastore, if index does not exist - no-op
 context.index.delete.parquet('table.parquet')
+```
+
+### Persistent tables API
+Package also supports index for persistent tables that are saved using `saveAsTable()` in Parquet
+format and accessible using `spark.table(tableName)`. API is available in Scala and Java.
+
+#### Scala
+```scala
+import com.github.lightcopy.implicits._
+
+// Create index for table name that exists in Spark catalog
+spark.index.create.indexByAll("col1", "col2", "col3").table("table_name")
+
+// Check if index exists for persistent table
+val exists: Boolean = spark.index.exists.table("table_name")
+
+// Query index for persistent table
+val df = spark.index.table("table_name").filter("col1 > 1")
+
+// Delete index for persistent table (does not drop table itself)
+spark.index.delete.table("table_name")
+```
+
+#### Java
+```java
+// Java API is very similar to Scala API
+import com.github.lightcopy.QueryContext;
+
+SparkSession spark = ...;
+
+QueryContext context = new QueryContext(spark);
+
+// Create index for persistent table
+context.index().create().indexByAll().table("table_name");
+
+// Check if index exists for persistent table
+boolean exists = context.index().exists().table("table_name");
+
+// Run query for indexed persistent table
+Dataset<Row> df = context.index().table("table_name").filter("col2 = 'c'");
+
+// Delete index from metastore (does not drop table)
+context.index().delete().table("table_name");
 ```
 
 ## Building From Source

--- a/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
+++ b/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
@@ -211,7 +211,8 @@ private[sql] case class CreateIndexCommand(
     this
   }
 
-  private def createIndex(path: String): Unit = {
+  /** Public for Python API */
+  def createIndex(path: String): Unit = {
     this.options += "path" -> path
     IndexedDataSource(
       Metastore.getOrCreate(sparkSession),
@@ -252,7 +253,8 @@ private[sql] case class ExistsIndexCommand(
     private var source: String,
     private val options: MutableHashMap[String, String]) {
 
-  private def existsIndex(path: String): Boolean = {
+  /** Public for Python API */
+  def existsIndex(path: String): Boolean = {
     this.options += "path" -> path
     IndexedDataSource(
       Metastore.getOrCreate(sparkSession),
@@ -287,7 +289,8 @@ private[sql] case class DeleteIndexCommand(
     private var source: String,
     private val options: MutableHashMap[String, String]) {
 
-  private def deleteIndex(path: String): Unit = {
+  /** Public for Python API */
+  def deleteIndex(path: String): Unit = {
     this.options += "path" -> path
     IndexedDataSource(
       Metastore.getOrCreate(sparkSession),

--- a/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
+++ b/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql
 
 import scala.collection.mutable.{HashMap => MutableHashMap}
 
-import org.apache.spark.sql.execution.datasources.{IndexedDataSource, Metastore}
+import org.apache.spark.sql.execution.datasources.{CatalogTableSource, IndexedDataSource, Metastore}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
 
@@ -81,7 +81,12 @@ class DataFrameIndexManager(sparkSession: SparkSession) {
    * @param tableName table name in catalog
    */
   def table(tableName: String): DataFrame = {
-    throw new UnsupportedOperationException()
+    sparkSession.baseRelationToDataFrame(
+      CatalogTableSource(
+        Metastore.getOrCreate(sparkSession),
+        tableName = tableName,
+        extraOptions = extraOptions.toMap).
+          asDataSource.resolveRelation())
   }
 
   /**
@@ -223,7 +228,11 @@ private[sql] case class CreateIndexCommand(
 
   /** Create index for Spark persistent table */
   def table(tableName: String): Unit = {
-    throw new UnsupportedOperationException()
+    CatalogTableSource(
+      Metastore.getOrCreate(sparkSession),
+      tableName = tableName,
+      extraOptions = this.options.toMap,
+      mode = mode).asDataSource.createIndex(this.columns)
   }
 
   /** Create index for Parquet table as datasource */
@@ -264,7 +273,10 @@ private[sql] case class ExistsIndexCommand(
 
   /** Check index for Spark persistent table */
   def table(tableName: String): Boolean = {
-    throw new UnsupportedOperationException()
+    CatalogTableSource(
+      Metastore.getOrCreate(sparkSession),
+      tableName = tableName,
+      extraOptions = this.options.toMap).asDataSource.existsIndex()
   }
 
   /** Check index for Parquet table as datasource */
@@ -300,7 +312,10 @@ private[sql] case class DeleteIndexCommand(
 
   /** Delete index for Spark persistent table */
   def table(tableName: String): Unit = {
-    throw new UnsupportedOperationException()
+    CatalogTableSource(
+      Metastore.getOrCreate(sparkSession),
+      tableName = tableName,
+      extraOptions = this.options.toMap).asDataSource.deleteIndex()
   }
 
   /** Delete index for Parquet table as datasource */

--- a/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
+++ b/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
@@ -77,6 +77,14 @@ class DataFrameIndexManager(sparkSession: SparkSession) {
   }
 
   /**
+   * Load indexed DataFrame from persistent table.
+   * @param tableName table name in catalog
+   */
+  def table(tableName: String): DataFrame = {
+    throw new UnsupportedOperationException()
+  }
+
+  /**
    * Load indexed DataFrame from Parquet table.
    * @param path filepath to the Parquet table (directory)
    */
@@ -203,11 +211,7 @@ private[sql] case class CreateIndexCommand(
     this
   }
 
-  /**
-   * Path to the table to build index for, can be local file system or HDFS.
-   * @param path
-   */
-  def table(path: String): Unit = {
+  private def createIndex(path: String): Unit = {
     this.options += "path" -> path
     IndexedDataSource(
       Metastore.getOrCreate(sparkSession),
@@ -216,10 +220,15 @@ private[sql] case class CreateIndexCommand(
       options = this.options.toMap).createIndex(this.columns)
   }
 
-  /** Path to the parquet table, forces source to be Parquet */
+  /** Create index for Spark persistent table */
+  def table(tableName: String): Unit = {
+    throw new UnsupportedOperationException()
+  }
+
+  /** Create index for Parquet table as datasource */
   def parquet(path: String): Unit = {
     this.source = IndexedDataSource.parquet
-    table(path)
+    createIndex(path)
   }
 
   /** Get currently set source, for testing only */
@@ -243,8 +252,7 @@ private[sql] case class ExistsIndexCommand(
     private var source: String,
     private val options: MutableHashMap[String, String]) {
 
-  /** Path to the table to check index for */
-  def table(path: String): Boolean = {
+  private def existsIndex(path: String): Boolean = {
     this.options += "path" -> path
     IndexedDataSource(
       Metastore.getOrCreate(sparkSession),
@@ -252,10 +260,15 @@ private[sql] case class ExistsIndexCommand(
       options = this.options.toMap).existsIndex()
   }
 
-  /** Path to the parquet table to check existence of index for, forces Parquet source */
+  /** Check index for Spark persistent table */
+  def table(tableName: String): Boolean = {
+    throw new UnsupportedOperationException()
+  }
+
+  /** Check index for Parquet table as datasource */
   def parquet(path: String): Boolean = {
     this.source = IndexedDataSource.parquet
-    table(path)
+    existsIndex(path)
   }
 
   /** Get currently set source, for testing only */
@@ -274,8 +287,7 @@ private[sql] case class DeleteIndexCommand(
     private var source: String,
     private val options: MutableHashMap[String, String]) {
 
-  /** Path to the table to delete index for */
-  def table(path: String): Unit = {
+  private def deleteIndex(path: String): Unit = {
     this.options += "path" -> path
     IndexedDataSource(
       Metastore.getOrCreate(sparkSession),
@@ -283,10 +295,15 @@ private[sql] case class DeleteIndexCommand(
       options = this.options.toMap).deleteIndex()
   }
 
-  /** Path to the parquet table to delete index for, forces Parquet source */
+  /** Delete index for Spark persistent table */
+  def table(tableName: String): Unit = {
+    throw new UnsupportedOperationException()
+  }
+
+  /** Delete index for Parquet table as datasource */
   def parquet(path: String): Unit = {
     this.source = IndexedDataSource.parquet
-    table(path)
+    deleteIndex(path)
   }
 
   /** Get currently set source, for testing only */

--- a/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
+++ b/src/main/scala/org/apache/spark/sql/DataFrameIndexManager.scala
@@ -85,8 +85,7 @@ class DataFrameIndexManager(sparkSession: SparkSession) {
       CatalogTableSource(
         Metastore.getOrCreate(sparkSession),
         tableName = tableName,
-        extraOptions = extraOptions.toMap).
-          asDataSource.resolveRelation())
+        options = extraOptions.toMap).asDataSource.resolveRelation())
   }
 
   /**
@@ -231,7 +230,7 @@ private[sql] case class CreateIndexCommand(
     CatalogTableSource(
       Metastore.getOrCreate(sparkSession),
       tableName = tableName,
-      extraOptions = this.options.toMap,
+      options = this.options.toMap,
       mode = mode).asDataSource.createIndex(this.columns)
   }
 
@@ -276,7 +275,7 @@ private[sql] case class ExistsIndexCommand(
     CatalogTableSource(
       Metastore.getOrCreate(sparkSession),
       tableName = tableName,
-      extraOptions = this.options.toMap).asDataSource.existsIndex()
+      options = this.options.toMap).asDataSource.existsIndex()
   }
 
   /** Check index for Parquet table as datasource */
@@ -315,7 +314,7 @@ private[sql] case class DeleteIndexCommand(
     CatalogTableSource(
       Metastore.getOrCreate(sparkSession),
       tableName = tableName,
-      extraOptions = this.options.toMap).asDataSource.deleteIndex()
+      options = this.options.toMap).asDataSource.deleteIndex()
   }
 
   /** Delete index for Parquet table as datasource */

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogTableSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogTableSource.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.BatchedDataSourceScanExec
+
+/** Catalog table info that is used to reconstruct data source */
+sealed case class CatalogTableInfo(
+    format: String,
+    inputPath: String,
+    metadata: Map[String, String])
+
+/** Source for catalog tables */
+case class CatalogTableSource(
+    private val metastore: Metastore,
+    private val tableName: String,
+    private val extraOptions: Map[String, String],
+    private val mode: SaveMode = SaveMode.ErrorIfExists) extends Logging {
+  // metadata keys to extract
+  val FORMAT = "Format"
+  val INPUT_PATHS = "InputPaths"
+  // parse table identifier and build logical plan
+  val tableIdent = metastore.session.sessionState.sqlParser.parseTableIdentifier(tableName)
+  val plan = metastore.session.sessionState.catalog.lookupRelation(tableIdent)
+  val info = executeBatchDataSourcePlan(plan)
+  logInfo(s"Catalog table info $info")
+
+  private def executeBatchDataSourcePlan(plan: LogicalPlan): CatalogTableInfo = {
+    val qe = metastore.session.sessionState.executePlan(plan)
+    qe.assertAnalyzed
+    qe.sparkPlan match {
+      case scanExec: BatchedDataSourceScanExec =>
+        val format = scanExec.metadata.
+          getOrElse(FORMAT, sys.error(s"Failed to look up format for $scanExec"))
+        // expected only single path
+        val inputPath = scanExec.metadata.
+          getOrElse(INPUT_PATHS, sys.error(s"Failed to look up input path for $scanExec"))
+        val options = extraOptions + ("path" -> inputPath)
+        CatalogTableInfo(format, inputPath, options)
+      case other =>
+        throw new UnsupportedOperationException(s"$other")
+    }
+  }
+
+  /** Convert table source into indexed datasource */
+  def asDataSource: IndexedDataSource = {
+    IndexedDataSource(
+      metastore = metastore,
+      className = info.format,
+      mode = mode,
+      options = info.metadata,
+      catalogTable = Some(info))
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogTableSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogTableSource.scala
@@ -47,11 +47,12 @@ case class CatalogTableSource(
     qe.assertAnalyzed
     qe.sparkPlan match {
       case scanExec: BatchedDataSourceScanExec =>
-        val format = scanExec.metadata.
-          getOrElse(FORMAT, sys.error(s"Failed to look up format for $scanExec"))
-        // expected only single path
-        val inputPath = scanExec.metadata.
-          getOrElse(INPUT_PATHS, sys.error(s"Failed to look up input path for $scanExec"))
+        assert(scanExec.metadata.contains(FORMAT), s"$FORMAT for $scanExec")
+        assert(scanExec.metadata.contains(INPUT_PATHS), s"$INPUT_PATHS for $scanExec")
+        // format describes subclass of FileFormat, and reference is slightly different from
+        // datasource API, also we expect only single path/directory
+        val format = scanExec.metadata(FORMAT)
+        val inputPath = scanExec.metadata(INPUT_PATHS)
         val extendedOptions = options + ("path" -> inputPath)
         CatalogTableInfo(format, inputPath, extendedOptions)
       case other =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+/**
+ * [[IndexIdentifier]] describes index location in metastore by providing information about
+ * metastore support identifier and dataspace for index, e.g. datasource or catalog table.
+ */
+abstract class IndexLocationSpec private[datasources] {
+
+  /** Raw value for identifier, will be resolved on the first access */
+  protected def unresolvedIndentifier: String
+
+  /** Raw value for dataspace, will be resolved on the first access */
+  protected def unresolvedDataspace: String
+
+  /** Support string identifier */
+  lazy val identifier: String = {
+    validate(unresolvedIndentifier, "identifier")
+    unresolvedIndentifier
+  }
+
+  /** Dataspace identifier, must be one of the supported spaces */
+  lazy val dataspace: String = {
+    validate(unresolvedDataspace, "dataspace")
+    unresolvedDataspace
+  }
+
+  /** Validate property of the location spec */
+  private def validate(value: String, property: String): Unit = {
+    require(value != null && value.nonEmpty, s"Empty $property")
+    value.foreach { ch =>
+      require(ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'z', s"Invalid character $ch in " +
+        s"$property $value. Only lowercase alpha-numeric characters are supported")
+    }
+  }
+
+  override def toString(): String = {
+    s"[$dataspace/$identifier]"
+  }
+}
+
+/** Location spec for datasource table */
+private[datasources] case class SourceLocationSpec(
+    unresolvedIndentifier: String)
+  extends IndexLocationSpec {
+
+  override protected def unresolvedDataspace: String = "source"
+}
+
+/** Location spec for catalog (persisten) table */
+private[datasources] case class CatalogLocationSpec(
+    unresolvedIndentifier: String)
+  extends IndexLocationSpec {
+
+  override protected def unresolvedDataspace: String = "catalog"
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexedDataSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexedDataSource.scala
@@ -57,7 +57,8 @@ case class IndexedDataSource(
         }
         logInfo(s"Loading index for $s, table=${tablePath.getPath}")
 
-        val indexCatalog = metastore.load(s.identifier, tablePath.getPath) { status =>
+        val spec = SourceLocationSpec(s.identifier)
+        val indexCatalog = metastore.load(spec, tablePath.getPath) { status =>
           s.loadIndex(metastore, status)
         }
 
@@ -89,7 +90,8 @@ case class IndexedDataSource(
       val partitionSpec = catalog.partitionSpec
       // ignore filtering expression for partitions, fetch all available files
       val allFiles = catalog.listFiles(Nil)
-      metastore.create(s.identifier, tablePath.getPath, mode) { (status, isAppend) =>
+      val spec = SourceLocationSpec(s.identifier)
+      metastore.create(spec, tablePath.getPath, mode) { (status, isAppend) =>
         s.createIndex(metastore, status, tablePath, isAppend, partitionSpec, allFiles, columns)
       }
     case other =>
@@ -101,7 +103,8 @@ case class IndexedDataSource(
     case s: MetastoreSupport =>
       Try {
         logInfo(s"Check index for $s, table=${tablePath.getPath}")
-        metastore.exists(s.identifier, tablePath.getPath)
+        val spec = SourceLocationSpec(s.identifier)
+        metastore.exists(spec, tablePath.getPath)
       } match {
         case Success(exists) =>
           exists
@@ -117,7 +120,8 @@ case class IndexedDataSource(
   def deleteIndex(): Unit = providingClass.newInstance() match {
     case s: MetastoreSupport =>
       logInfo(s"Delete index for $s, table=${tablePath.getPath}")
-      metastore.delete(s.identifier, tablePath.getPath) { case status =>
+      val spec = SourceLocationSpec(s.identifier)
+      metastore.delete(spec, tablePath.getPath) { case status =>
         s.deleteIndex(metastore, status) }
     case other =>
       throw new UnsupportedOperationException(s"Deletion of index is not supported by $other")

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -151,8 +151,7 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
 
         // should result in no-op since original table already exists
         spark.range(11, 16).withColumn("str", lit("abc")).write.parquet(dir.toString / "test")
-        spark.index.create.mode("ignore").indexBy("id", "str").
-          table(dir.toString / "test")
+        spark.index.create.mode("ignore").indexBy("id", "str").parquet(dir.toString / "test")
         spark.index.exists.parquet(dir.toString / "test") should be (true)
         // check result by quering on different id
         spark.index.parquet(dir.toString / "test").filter(col("id") === 12).count should be (0)

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql
 
 import java.io.FileNotFoundException
 
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.internal.IndexConf._
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types._
@@ -876,6 +877,105 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         val df2 = spark.read.parquet(dir.toString / "table-no-metadata")
         df1.schema should be (df2.schema)
         df1.schema.fields.map(_.metadata) should be (df2.schema.fields.map(_.metadata))
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////////////////
+  // Catalog table index tests
+  //////////////////////////////////////////////////////////////
+
+  test("index catalog table in Parquet format") {
+    withTempDir { dir =>
+      withSQLConf(
+          "spark.sql.sources.default" -> "parquet",
+          METASTORE_LOCATION.key -> dir.toString / "metastore") {
+        val sqlContext = spark.sqlContext
+        import sqlContext.implicits._
+        val df = Seq(
+          ("a", 1, true),
+          ("b", 2, false),
+          ("c", 3, true)
+        ).toDF("col1", "col2", "col3")
+
+        val tableName = "test_parquet_table"
+        df.write.saveAsTable(tableName)
+        try {
+          spark.index.create.indexByAll.table(tableName)
+          spark.index.exists.table(tableName) should be (true)
+          val res1 = spark.index.table(tableName).filter("col1 = 2")
+          val res2 = spark.table(tableName).filter("col1 = 2")
+          checkAnswer(res1, res2)
+          spark.index.delete.table(tableName)
+          spark.index.exists.table(tableName) should be (false)
+        } finally {
+          spark.sql(s"drop table $tableName")
+        }
+      }
+    }
+  }
+
+  test("create different index for catalog table and datasource with same path") {
+    withTempDir { dir =>
+      withSQLConf(
+          "spark.sql.sources.default" -> "parquet",
+          METASTORE_LOCATION.key -> dir.toString / "metastore") {
+        val df = spark.range(0, 10)
+        val tableName = "test_parquet_table"
+        df.write.saveAsTable(tableName)
+        val tableLocation = spark.conf.get("spark.sql.warehouse.dir").
+          replace("${system:user.dir}", fs.getWorkingDirectory.toString) / "test_parquet_table"
+        try {
+          spark.index.create.indexByAll.table(tableName)
+          spark.index.create.indexByAll.parquet(tableLocation)
+
+          spark.index.exists.table(tableName) should be (true)
+          spark.index.exists.parquet(tableLocation) should be (true)
+        } finally {
+          spark.sql(s"drop table $tableName")
+        }
+      }
+    }
+  }
+
+  test("overwrite index for catalog table") {
+    withTempDir { dir =>
+      withSQLConf(
+          "spark.sql.sources.default" -> "parquet",
+          METASTORE_LOCATION.key -> dir.toString / "metastore") {
+        val df = spark.range(0, 10).withColumn("col1", lit("abc"))
+        val tableName = "test_parquet_table"
+        df.write.saveAsTable(tableName)
+        try {
+          spark.index.create.indexByAll.table(tableName)
+          spark.index.exists.table(tableName) should be (true)
+          spark.index.create.mode("overwrite").indexBy("id").table(tableName)
+          spark.index.exists.table(tableName) should be (true)
+        } finally {
+          spark.sql(s"drop table $tableName")
+        }
+      }
+    }
+  }
+
+  test("fail to query index when underlying catalog table is dropped") {
+    withTempDir { dir =>
+      withSQLConf(
+          "spark.sql.sources.default" -> "parquet",
+          METASTORE_LOCATION.key -> dir.toString / "metastore") {
+        val df = spark.range(0, 10).withColumn("col1", lit("abc"))
+        val tableName = "test_parquet_table"
+        df.write.saveAsTable(tableName)
+        try {
+          spark.index.create.indexByAll.table(tableName)
+        } finally {
+          spark.sql(s"drop table $tableName")
+        }
+
+        val err = intercept[NoSuchTableException] {
+          spark.index.table(tableName)
+        }
+        err.getMessage.contains(s"Table or view '$tableName' not found in database")
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -924,7 +924,7 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         val tableName = "test_parquet_table"
         df.write.saveAsTable(tableName)
         val tableLocation = spark.conf.get("spark.sql.warehouse.dir").
-          replace("${system:user.dir}", fs.getWorkingDirectory.toString) / "test_parquet_table"
+          replace("${system:user.dir}", System.getProperty("user.dir")) / "test_parquet_table"
         try {
           spark.index.create.indexByAll.table(tableName)
           spark.index.create.indexByAll.parquet(tableLocation)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/CatalogTableSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/CatalogTableSourceSuite.scala
@@ -49,7 +49,7 @@ class CatalogTableSourceSuite extends UnitTestSuite with SparkLocal with TestMet
         val err = intercept[UnsupportedOperationException] {
           CatalogTableSource(metastore, view, options = Map.empty)
         }
-        assert(err.getMessage.contains("Range (0, 10, step=1"))
+        assert(err.getMessage.contains("Range (0, 10"))
       } finally {
         spark.catalog.dropTempView(view)
       }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/CatalogTableSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/CatalogTableSourceSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+
+import com.github.lightcopy.testutil.{SparkLocal, UnitTestSuite}
+import com.github.lightcopy.testutil.implicits._
+
+class CatalogTableSourceSuite extends UnitTestSuite with SparkLocal with TestMetastore {
+  override def beforeAll {
+    startSparkSession()
+  }
+
+  override def afterAll {
+    stopSparkSession()
+  }
+
+  test("fail to resolve non-existent table in catalog") {
+    withTempDir { dir =>
+      val metastore = testMetastore(spark, dir / "test")
+      val err = intercept[NoSuchTableException] {
+        CatalogTableSource(metastore, "abc", options = Map.empty)
+      }
+      assert(err.getMessage.contains("Table or view 'abc' not found in database"))
+    }
+  }
+
+  test("fail if source is temporary view and not BatchedDataSourceScanExec") {
+    withTempDir { dir =>
+      val metastore = testMetastore(spark, dir / "test")
+      val view = "range_view"
+      spark.range(0, 10).createOrReplaceTempView(view)
+      try {
+        val err = intercept[UnsupportedOperationException] {
+          CatalogTableSource(metastore, view, options = Map.empty)
+        }
+        assert(err.getMessage.contains("Range (0, 10, step=1"))
+      } finally {
+        spark.catalog.dropTempView(view)
+      }
+    }
+  }
+
+  test("convert Parquet catalog table into indexed source") {
+    withTempDir { dir =>
+      withSQLConf("spark.sql.sources.default" -> "parquet") {
+        val metastore = testMetastore(spark, dir / "test")
+        val tableName = "test_parquet_table"
+        spark.range(0, 10).filter("id > 0").write.saveAsTable(tableName)
+        try {
+          val source = CatalogTableSource(metastore, tableName, options = Map("key" -> "value"))
+          val indexedSource = source.asDataSource
+          indexedSource.className should be ("ParquetFormat")
+          indexedSource.mode should be (source.mode)
+          for ((key, value) <- source.options) {
+            indexedSource.options.get(key) should be (Some(value))
+          }
+          indexedSource.options.get("path").isDefined should be (true)
+          indexedSource.catalogTable.isDefined should be (true)
+        } finally {
+          spark.sql(s"drop table $tableName")
+        }
+      }
+    }
+  }
+
+  test("fail to convert JSON catalog table into indexed source") {
+    // JSON source is org.apache.spark.sql.execution.RowDataSourceScanExec
+    withTempDir { dir =>
+      withSQLConf("spark.sql.sources.default" -> "json") {
+        val metastore = testMetastore(spark, dir / "test")
+        val tableName = "test_json_table"
+        spark.range(0, 10).write.saveAsTable(tableName)
+        try {
+          val err = intercept[UnsupportedOperationException] {
+            CatalogTableSource(metastore, tableName, options = Map("key" -> "value"))
+          }
+          err.getMessage.contains(s"Scan json ${spark.catalog.currentDatabase}.$tableName")
+        } finally {
+          spark.sql(s"drop table $tableName")
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpecSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpecSuite.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import com.github.lightcopy.testutil.UnitTestSuite
+import com.github.lightcopy.testutil.implicits._
+
+/** Test location spec for validation */
+private[datasources] case class TestLocationSpec(
+    unresolvedIndentifier: String,
+    unresolvedDataspace: String) extends IndexLocationSpec
+
+class IndexLocationSpecSuite extends UnitTestSuite {
+  test("IndexLocationSpec - empty/null identifier") {
+    var err = intercept[IllegalArgumentException] {
+      TestLocationSpec(null, "value").identifier
+    }
+    assert(err.getMessage.contains("Empty identifier"))
+
+    err = intercept[IllegalArgumentException] {
+      TestLocationSpec("", "value").identifier
+    }
+    assert(err.getMessage.contains("Empty identifier"))
+  }
+
+  test("IndexLocationSpec - empty/null dataspace") {
+    var err = intercept[IllegalArgumentException] {
+      TestLocationSpec("value", null).dataspace
+    }
+    assert(err.getMessage.contains("Empty dataspace"))
+
+    err = intercept[IllegalArgumentException] {
+      TestLocationSpec("value", "").dataspace
+    }
+    assert(err.getMessage.contains("Empty dataspace"))
+  }
+
+  test("IndexLocationSpec - invalid set of characters") {
+    // identifier contains spaces
+    var err = intercept[IllegalArgumentException] {
+      TestLocationSpec("test ", "ok").identifier
+    }
+    assert(err.getMessage.contains("Invalid character   in identifier test "))
+
+    // all characters are invalid
+    err = intercept[IllegalArgumentException] {
+      TestLocationSpec("#$%", "ok").identifier
+    }
+    assert(err.getMessage.contains("Invalid character # in identifier #$%"))
+
+    // identifier contains uppercase characters
+    err = intercept[IllegalArgumentException] {
+      TestLocationSpec("Test", "ok").identifier
+    }
+    assert(err.getMessage.contains("Invalid character T in identifier Test"))
+
+    // identifier contains underscore
+    err = intercept[IllegalArgumentException] {
+      TestLocationSpec("test_123", "ok").identifier
+    }
+    assert(err.getMessage.contains("Invalid character _ in identifier test_123"))
+
+    // identifier contains hyphen
+    err = intercept[IllegalArgumentException] {
+      TestLocationSpec("test-123", "ok").identifier
+    }
+    assert(err.getMessage.contains("Invalid character - in identifier test-123"))
+  }
+
+  test("IndexLocationSpec - valid identifier") {
+    TestLocationSpec("test", "test").identifier
+    TestLocationSpec("test1239", "test1239").identifier
+    TestLocationSpec("012345689", "012345689").identifier
+    TestLocationSpec("0123test", "0123test").identifier
+  }
+
+  test("IndexLocationSpec - source spec") {
+    val spec = SourceLocationSpec("parquet")
+    spec.identifier should be ("parquet")
+    spec.dataspace should be ("source")
+  }
+
+  test("IndexLocationSpec - catalog spec") {
+    val spec = CatalogLocationSpec("parquet")
+    spec.identifier should be ("parquet")
+    spec.dataspace should be ("catalog")
+  }
+
+  test("IndexLocationSpec - toString") {
+    TestLocationSpec("identifier", "dataspace").toString should be ("[dataspace/identifier]")
+    SourceLocationSpec("parquet").toString should be ("[source/parquet]")
+    CatalogLocationSpec("parquet").toString should be ("[catalog/parquet]")
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/IndexedDataSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/IndexedDataSourceSuite.scala
@@ -130,7 +130,8 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("resolveRelation - fail if index directory does not contain SUCCESS file") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      mkdirs(metastore.location("test", dir))
+      val spec = SourceLocationSpec("test")
+      mkdirs(metastore.location(spec, dir))
       val source = IndexedDataSource(
         metastore,
         classOf[TestMetastoreSupport].getCanonicalName,
@@ -146,7 +147,8 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("resolveRelation - return HadoopFsRelation for metastore support") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val location = metastore.location("test", dir)
+      val spec = SourceLocationSpec("test")
+      val location = metastore.location(spec, dir)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
       val source = IndexedDataSource(
@@ -212,7 +214,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("existsIndex - return false if index directory does not contain SUCCESS file") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location("test", dir)
+      val path = metastore.location(SourceLocationSpec("test"), dir)
       // create directory in index metastore, do not mark it as success
       mkdirs(path)
       val source = IndexedDataSource(
@@ -226,7 +228,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("existsIndex - return false if table path does not exist") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location("test", dir)
+      val path = metastore.location(SourceLocationSpec("test"), dir)
       // check index existince for non-existent table path
       val source = IndexedDataSource(
         metastore,
@@ -239,7 +241,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("existsIndex - invoke metastore support method") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location("test", dir)
+      val path = metastore.location(SourceLocationSpec("test"), dir)
       // create directory in index metastore and mark it as success to check index existence
       mkdirs(path)
       Metastore.markSuccess(fs, path)
@@ -268,7 +270,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("deleteIndex - invoke metastore support method") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location("test", dir)
+      val path = metastore.location(SourceLocationSpec("test"), dir)
       // create directory in index metastore, otherwise delete method is no-op
       mkdirs(path)
       val source = IndexedDataSource(

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/IndexedDataSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/IndexedDataSourceSuite.scala
@@ -289,6 +289,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
     val datasources = Seq(
       "parquet",
       "org.apache.spark.sql.execution.datasources.parquet",
+      "ParquetFormat",
       IndexedDataSource.parquet)
     for (source <- datasources) {
       IndexedDataSource.resolveClassName(source) should be (IndexedDataSource.parquet)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -185,8 +185,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val location = metastore.location("identifier", new Path("/tmp/table"))
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.Append) {
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, new Path("/tmp/table"))
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.Append) {
         case (status, isAppend) =>
           triggered = true
           status.isDirectory should be (true)
@@ -202,8 +203,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val location = metastore.location("identifier", new Path("/tmp/table"))
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.Overwrite) {
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, new Path("/tmp/table"))
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.Overwrite) {
         case (status, isAppend) =>
           triggered = true
           status.isDirectory should be (true)
@@ -219,8 +221,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val location = metastore.location("identifier", new Path("/tmp/table"))
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.ErrorIfExists) {
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, new Path("/tmp/table"))
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.ErrorIfExists) {
         case (status, isAppend) =>
           triggered = true
           status.isDirectory should be (true)
@@ -236,8 +239,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val location = metastore.location("identifier", new Path("/tmp/table"))
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.Ignore) {
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, new Path("/tmp/table"))
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.Ignore) {
         case (status, isAppend) =>
           triggered = true
           status.isDirectory should be (true)
@@ -253,10 +257,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       // create directory and existing file
       touch(path / "metadata")
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.Append) {
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.Append) {
         case (status, isAppend) =>
           triggered = true
           status.isDirectory should be (true)
@@ -274,10 +279,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       // create directory and existing file
       touch(path / "metadata")
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.Overwrite) {
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.Overwrite) {
         case (status, isAppend) =>
           triggered = true
           status.isDirectory should be (true)
@@ -294,10 +300,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("create - existing path, ErrorIfExists mode") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       mkdirs(path)
       val err = intercept[IOException] {
-        metastore.create("identifier", new Path("/tmp/table"), SaveMode.ErrorIfExists) {
+        metastore.create(spec, new Path("/tmp/table"), SaveMode.ErrorIfExists) {
           case (status, isAppend) => // do nothing
         }
       }
@@ -309,9 +316,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       mkdirs(path)
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.Ignore) {
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.Ignore) {
         case (status, isAppend) => triggered = true
       }
       // should not invoke closure
@@ -322,9 +330,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("create - delete directory when fails, mode is not Append") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
+      val spec = SourceLocationSpec("identifier")
       var path: Path = null
       val err = intercept[IllegalStateException] {
-        metastore.create("identifier", new Path("/tmp/table"), SaveMode.Overwrite) {
+        metastore.create(spec, new Path("/tmp/table"), SaveMode.Overwrite) {
           case (status, isAppend) =>
             // path should exist before exception is thrown
             path = status.getPath
@@ -341,10 +350,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       // create folder to trigger append mode
-      mkdirs(metastore.location("identifier", new Path("/tmp/table")))
+      val spec = SourceLocationSpec("identifier")
+      mkdirs(metastore.location(spec, new Path("/tmp/table")))
       var path: Path = null
       val err = intercept[IllegalStateException] {
-        metastore.create("identifier", new Path("/tmp/table"), SaveMode.Append) {
+        metastore.create(spec, new Path("/tmp/table"), SaveMode.Append) {
           case (status, isAppend) =>
             // path should exist before exception is thrown
             path = status.getPath
@@ -362,11 +372,12 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("create - invalidate cache before creating index") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       metastore.cache.put(path, new TestIndexCatalog())
       metastore.cache.asMap.size should be (1)
 
-      metastore.create("identifier", new Path("/tmp/table"), SaveMode.ErrorIfExists) {
+      metastore.create(spec, new Path("/tmp/table"), SaveMode.ErrorIfExists) {
         case (status, isAppend) => // no-op
       }
       metastore.cache.asMap.size should be (0)
@@ -382,7 +393,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      metastore.delete("identifier", new Path("/tmp/table")) {
+      metastore.delete(SourceLocationSpec("identifier"), new Path("/tmp/table")) {
         case status => triggered = true
       }
       // should not invoke closure
@@ -394,9 +405,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       mkdirs(path)
-      metastore.delete("identifier", new Path("/tmp/table")) {
+      metastore.delete(spec, new Path("/tmp/table")) {
         case status => triggered = true
       }
       triggered should be (true)
@@ -407,12 +419,13 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("delete - invalidate cache before deleting index") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       metastore.cache.put(path, new TestIndexCatalog())
       metastore.cache.asMap.size should be (1)
 
       mkdirs(path)
-      metastore.delete("identifier", new Path("/tmp/table")) {
+      metastore.delete(spec, new Path("/tmp/table")) {
         case status => // no-op
       }
       metastore.fs.exists(path) should be (false)
@@ -425,9 +438,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("delete - do not invalidate cache if index does not exist") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val path = metastore.location(spec, new Path("/tmp/table"))
       metastore.cache.put(path, new TestIndexCatalog())
-      metastore.delete("identifier", new Path("/tmp/table")) {
+      metastore.delete(spec, new Path("/tmp/table")) {
         case status => // no-op
       }
       // metastore cache should still contain above entry
@@ -444,7 +458,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       val err = intercept[IOException] {
-        metastore.load("identifier", new Path("/tmp/table")) {
+        metastore.load(SourceLocationSpec("identifier"), new Path("/tmp/table")) {
           case status => new TestIndexCatalog()
         }
       }
@@ -455,10 +469,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("load - existing directory without SUCCESS file") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val location = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, new Path("/tmp/table"))
       mkdirs(location)
       val err = intercept[IOException] {
-        metastore.load("identifier", new Path("/tmp/table")) {
+        metastore.load(spec, new Path("/tmp/table")) {
           case status => new TestIndexCatalog()
         }
       }
@@ -469,11 +484,12 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("load - existing directory") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val location = metastore.location("identifier", new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, new Path("/tmp/table"))
       mkdirs(location)
       Metastore.markSuccess(fs, location)
       var triggered = false
-      metastore.load("identifier", new Path("/tmp/table")) {
+      metastore.load(spec, new Path("/tmp/table")) {
         case status =>
           triggered = true
           new TestIndexCatalog()
@@ -488,14 +504,15 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       val path = new Path("/tmp/table")
-      val location = metastore.location("identifier", path)
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, path)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
 
-      val catalog1 = metastore.load("identifier", path) {
+      val catalog1 = metastore.load(spec, path) {
         case status => new TestIndexCatalog()
       }
-      val catalog2 = metastore.load("identifier", path) {
+      val catalog2 = metastore.load(spec, path) {
         case status =>
           throw new IllegalStateException("Expected to use cache, failed to load entry")
       }
@@ -513,7 +530,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       val path = new Path("/tmp/table")
-      metastore.exists("identifier", path) should be (false)
+      metastore.exists(SourceLocationSpec("identifier"), path) should be (false)
     }
   }
 
@@ -521,9 +538,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       val path = new Path("/tmp/table")
-      val location = metastore.location("identifier", path)
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, path)
       mkdirs(location)
-      metastore.exists("identifier", path) should be (false)
+      metastore.exists(spec, path) should be (false)
     }
   }
 
@@ -531,10 +549,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       val path = new Path("/tmp/table")
-      val location = metastore.location("identifier", path)
+      val spec = SourceLocationSpec("identifier")
+      val location = metastore.location(spec, path)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
-      metastore.exists("identifier", path) should be (true)
+      metastore.exists(spec, path) should be (true)
     }
   }
 
@@ -545,8 +564,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - local fully-qualified path") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      metastore.location("test", new Path("file:/tmp/path")) should be (
-        new Path("file:" + dir.toString / "test" / "file" / "tmp" / "path")
+      val spec = SourceLocationSpec("test")
+      metastore.location(spec, new Path("file:/tmp/path")) should be (
+        new Path("file:" + s"$dir" / spec.dataspace / spec.identifier / "file" / "tmp" / "path")
       )
     }
   }
@@ -554,8 +574,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - hdfs fully-qualified path") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      metastore.location("test", new Path("hdfs://sandbox:8020/tmp/path")) should be (
-        new Path("file:" + dir.toString / "test" / "hdfs" / "tmp" / "path")
+      val spec = SourceLocationSpec("test")
+      metastore.location(spec, new Path("hdfs://sandbox:8020/tmp/path")) should be (
+        new Path("file:" + s"$dir" / spec.dataspace / spec.identifier / "hdfs" / "tmp" / "path")
       )
     }
   }
@@ -563,8 +584,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - non-qualified path part") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      metastore.location("test", new Path("tmp/something")) should be (
-        new Path("file:" + dir.toString / "test" / "file" / "tmp" / "something")
+      val spec = SourceLocationSpec("test")
+      metastore.location(spec, new Path("tmp/something")) should be (
+        new Path(
+          "file:" + s"$dir" / spec.dataspace / spec.identifier / "file" / "tmp" / "something")
       )
     }
   }
@@ -572,20 +595,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - empty path") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
+      val spec = SourceLocationSpec("test")
       val err = intercept[IllegalArgumentException] {
-        metastore.location("test", new Path(""))
+        metastore.location(spec, new Path(""))
       }
       assert(err.getMessage.contains("Can not create a Path from an empty string"))
-    }
-  }
-
-  test("location - empty identifier") {
-    withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
-      val metastore = testMetastore(spark, dir)
-      val err = intercept[IllegalArgumentException] {
-        metastore.location("", new Path("/tmp/path"))
-      }
-      assert(err.getMessage.contains("Empty invalid identifier"))
     }
   }
 
@@ -594,57 +608,6 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       val metastore = testMetastore(spark, dir)
       metastore.toString should be (s"Metastore[metastore=file:$dir]")
     }
-  }
-
-  test("validateSupportIdentifier - empty or invalid identifier") {
-    var err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier(null)
-    }
-    assert(err.getMessage.contains("Empty invalid identifier"))
-
-    err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier("")
-    }
-    assert(err.getMessage.contains("Empty invalid identifier"))
-  }
-
-  test("validateSupportIdentifier - invalid set of characters") {
-    // identifier contains spaces
-    var err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier("test ")
-    }
-    assert(err.getMessage.contains("Invalid character"))
-
-    // all characters are invalid
-    err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier("#$%")
-    }
-    assert(err.getMessage.contains("Invalid character"))
-
-    // identifier contains uppercase characters
-    err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier("Test")
-    }
-    assert(err.getMessage.contains("Invalid character"))
-
-    // identifier contains underscore
-    err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier("test_123")
-    }
-    assert(err.getMessage.contains("Invalid character"))
-
-    // identifier contains hyphen
-    err = intercept[IllegalArgumentException] {
-      Metastore.validateSupportIdentifier("test-123")
-    }
-    assert(err.getMessage.contains("Invalid character"))
-  }
-
-  test("validateSupportIdentifier - valid identifier") {
-    Metastore.validateSupportIdentifier("test")
-    Metastore.validateSupportIdentifier("test1239")
-    Metastore.validateSupportIdentifier("012345689")
-    Metastore.validateSupportIdentifier("0123test")
   }
 
   test("markSuccess/checkSuccessFile") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import java.io.IOException
 
-import org.apache.spark.sql.execution.datasources.TestMetastore
+import org.apache.spark.sql.execution.datasources.{TestMetastore, SourceLocationSpec}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.IndexConf._
 import org.apache.spark.sql.types._
@@ -268,7 +268,8 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
 
         val support = new ParquetMetastoreSupport()
-        val location = metastore.location(support.identifier, dir / "table")
+        val spec = SourceLocationSpec(support.identifier)
+        val location = metastore.location(spec, dir / "table")
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
           asInstanceOf[ParquetIndexCatalog]
@@ -302,7 +303,8 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
 
         val support = new ParquetMetastoreSupport()
-        val location = metastore.location(support.identifier, dir / "table")
+        val spec = SourceLocationSpec(support.identifier)
+        val location = metastore.location(spec, dir / "table")
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
           asInstanceOf[ParquetIndexCatalog]
@@ -337,7 +339,8 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
 
         val support = new ParquetMetastoreSupport()
-        val location = metastore.location(support.identifier, dir / "table")
+        val spec = SourceLocationSpec(support.identifier)
+        val location = metastore.location(spec, dir / "table")
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
           asInstanceOf[ParquetIndexCatalog]


### PR DESCRIPTION
This PR adds support for Spark persistent tables that are created with `saveAsTable`, only Parquet format is supported. Implementation introduces `CatalogTableSource` that parses table name and extracts information, including warehouse path for actual files. `CatalogTableSource` is then converted into `IndexedDataSource` and indexed similar to datasource tables.

PR introduces breaking change by adding identifier to metastore, to separate catalog tables from source tables and potentially other sources, meaning indexes that were created **before this patch** will not be read, and will require to recreate index for those tables.

Features like Python API and merging path into metastore identifier will be done in separate PRs.