### PR TITLE
Python API for persistent tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ context.index.delete.parquet('table.parquet')
 
 ### Persistent tables API
 Package also supports index for persistent tables that are saved using `saveAsTable()` in Parquet
-format and accessible using `spark.table(tableName)`. API is available in Scala and Java.
+format and accessible using `spark.table(tableName)`. API is available in Scala, Java and Python.
 
 #### Scala
 ```scala

--- a/README.md
+++ b/README.md
@@ -237,6 +237,25 @@ Dataset<Row> df = context.index().table("table_name").filter("col2 = 'c'");
 context.index().delete().table("table_name");
 ```
 
+#### Python
+```python
+from lightcopy.index import QueryContext
+
+context = QueryContext(spark)
+
+# Create index from Spark persistent table
+context.index.create.mode('overwrite').indexBy('col1', 'col2').table('table_name')
+
+# Check if index exists for persistent table. 'True' if exists in metastore, 'False' otherwise
+context.index.exists.table('table_name')
+
+# Query indexed persistent table
+df = context.index.table('table_name').filter('col1 = 123')
+
+# Delete index for persistent table (does not drop table)
+context.index.delete.table('table_name')
+```
+
 ## Building From Source
 This library is built using `sbt`, to build a JAR file simply run `sbt package` from project root.
 

--- a/python/src/lightcopy/index.py
+++ b/python/src/lightcopy/index.py
@@ -75,11 +75,11 @@ class CreateIndexCommand(object):
         self._columns = None
         return self
 
-    def _createIndex(self, path):
+    def _init_create_command(self):
         """
-        Create index for table path.
+        Consolidate options and return Java command to create index.
 
-        :param path: path to the table
+        :return: java create command
         """
         jcreate = self._manager._jdim.create()
         # set mode if available, otherwise will use default value in Scala code
@@ -91,6 +91,15 @@ class CreateIndexCommand(object):
             jcreate.indexByAll()
         else:
             jcreate.indexBy(self._columns)
+        return jcreate
+
+    def _createIndex(self, path):
+        """
+        Create index for table path.
+
+        :param path: path to the table
+        """
+        jcreate = self._init_create_command()
         jcreate.createIndex(path)
 
     def table(self, tableName):
@@ -99,7 +108,8 @@ class CreateIndexCommand(object):
 
         :param table: table name that exists in catalog
         """
-        raise NotImplementedError()
+        jcreate = self._init_create_command()
+        jcreate.table(tableName)
 
     def parquet(self, path):
         """
@@ -135,7 +145,7 @@ class ExistsIndexCommand(object):
         :param tableName: table name in catalog
         :return: True if index exists, False otherwise
         """
-        raise NotImplementedError()
+        return self._manager._jdim.exists().table(tableName)
 
     def parquet(self, path):
         """
@@ -172,7 +182,7 @@ class DeleteIndexCommand(object):
 
         :param tableName: table name in catalog
         """
-        raise NotImplementedError()
+        self._manager._jdim.delete().table(tableName)
 
     def parquet(self, path):
         """
@@ -266,7 +276,8 @@ class DataFrameIndexManager(object):
         :param tableName: table name in catalog
         :return: DataFrame instance
         """
-        raise NotImplementedError()
+        self._init_manager()
+        return DataFrame(self._jdim.table(tableName), self._sqlctx)
 
     def parquet(self, path):
         """


### PR DESCRIPTION
This PR adds Python API in addition to Java and Scala APIs for indexing catalog tables.