### PR TITLE
Update location spec

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpec.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.hadoop.fs.Path
+
 /**
  * [[IndexIdentifier]] describes index location in metastore by providing information about
  * metastore support identifier and dataspace for index, e.g. datasource or catalog table.
@@ -27,6 +29,9 @@ abstract class IndexLocationSpec private[datasources] {
 
   /** Raw value for dataspace, will be resolved on the first access */
   protected def unresolvedDataspace: String
+
+  /** Path to the source table that is backed by filesystem-based datasource */
+  def sourcePath: Path
 
   /** Support string identifier */
   lazy val identifier: String = {
@@ -50,13 +55,14 @@ abstract class IndexLocationSpec private[datasources] {
   }
 
   override def toString(): String = {
-    s"[$dataspace/$identifier]"
+    s"[$dataspace/$identifier, source=$sourcePath]"
   }
 }
 
 /** Location spec for datasource table */
 private[datasources] case class SourceLocationSpec(
-    unresolvedIndentifier: String)
+    unresolvedIndentifier: String,
+    sourcePath: Path)
   extends IndexLocationSpec {
 
   override protected def unresolvedDataspace: String = "source"
@@ -64,7 +70,8 @@ private[datasources] case class SourceLocationSpec(
 
 /** Location spec for catalog (persisten) table */
 private[datasources] case class CatalogLocationSpec(
-    unresolvedIndentifier: String)
+    unresolvedIndentifier: String,
+    sourcePath: Path)
   extends IndexLocationSpec {
 
   override protected def unresolvedDataspace: String = "catalog"

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpecSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/IndexLocationSpecSuite.scala
@@ -16,35 +16,38 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.hadoop.fs.Path
+
 import com.github.lightcopy.testutil.UnitTestSuite
 import com.github.lightcopy.testutil.implicits._
 
 /** Test location spec for validation */
 private[datasources] case class TestLocationSpec(
     unresolvedIndentifier: String,
-    unresolvedDataspace: String) extends IndexLocationSpec
+    unresolvedDataspace: String,
+    sourcePath: Path) extends IndexLocationSpec
 
 class IndexLocationSpecSuite extends UnitTestSuite {
   test("IndexLocationSpec - empty/null identifier") {
     var err = intercept[IllegalArgumentException] {
-      TestLocationSpec(null, "value").identifier
+      TestLocationSpec(null, "value", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Empty identifier"))
 
     err = intercept[IllegalArgumentException] {
-      TestLocationSpec("", "value").identifier
+      TestLocationSpec("", "value", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Empty identifier"))
   }
 
   test("IndexLocationSpec - empty/null dataspace") {
     var err = intercept[IllegalArgumentException] {
-      TestLocationSpec("value", null).dataspace
+      TestLocationSpec("value", null, new Path(".")).dataspace
     }
     assert(err.getMessage.contains("Empty dataspace"))
 
     err = intercept[IllegalArgumentException] {
-      TestLocationSpec("value", "").dataspace
+      TestLocationSpec("value", "", new Path(".")).dataspace
     }
     assert(err.getMessage.contains("Empty dataspace"))
   }
@@ -52,57 +55,77 @@ class IndexLocationSpecSuite extends UnitTestSuite {
   test("IndexLocationSpec - invalid set of characters") {
     // identifier contains spaces
     var err = intercept[IllegalArgumentException] {
-      TestLocationSpec("test ", "ok").identifier
+      TestLocationSpec("test ", "ok", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Invalid character   in identifier test "))
 
     // all characters are invalid
     err = intercept[IllegalArgumentException] {
-      TestLocationSpec("#$%", "ok").identifier
+      TestLocationSpec("#$%", "ok", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Invalid character # in identifier #$%"))
 
     // identifier contains uppercase characters
     err = intercept[IllegalArgumentException] {
-      TestLocationSpec("Test", "ok").identifier
+      TestLocationSpec("Test", "ok", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Invalid character T in identifier Test"))
 
     // identifier contains underscore
     err = intercept[IllegalArgumentException] {
-      TestLocationSpec("test_123", "ok").identifier
+      TestLocationSpec("test_123", "ok", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Invalid character _ in identifier test_123"))
 
     // identifier contains hyphen
     err = intercept[IllegalArgumentException] {
-      TestLocationSpec("test-123", "ok").identifier
+      TestLocationSpec("test-123", "ok", new Path(".")).identifier
     }
     assert(err.getMessage.contains("Invalid character - in identifier test-123"))
   }
 
   test("IndexLocationSpec - valid identifier") {
-    TestLocationSpec("test", "test").identifier
-    TestLocationSpec("test1239", "test1239").identifier
-    TestLocationSpec("012345689", "012345689").identifier
-    TestLocationSpec("0123test", "0123test").identifier
+    // test identifier
+    TestLocationSpec("test", "test", new Path(".")).identifier
+    TestLocationSpec("test1239", "test1239", new Path(".")).identifier
+    TestLocationSpec("012345689", "012345689", new Path(".")).identifier
+    TestLocationSpec("0123test", "0123test", new Path(".")).identifier
+    // test dataspace
+    TestLocationSpec("test", "test", new Path(".")).dataspace
+    TestLocationSpec("test1239", "test1239", new Path(".")).dataspace
+    TestLocationSpec("012345689", "012345689", new Path(".")).dataspace
+    TestLocationSpec("0123test", "0123test", new Path(".")).dataspace
+    // test source path
+    TestLocationSpec("a", "b", new Path("/tmp/test")).sourcePath should be (new Path("/tmp/test"))
+  }
+
+  test("IndexLocationSpec - empty path") {
+    val err = intercept[IllegalArgumentException] {
+      TestLocationSpec("a", "b", new Path(""))
+    }
+    assert(err.getMessage.contains("Can not create a Path from an empty string"))
   }
 
   test("IndexLocationSpec - source spec") {
-    val spec = SourceLocationSpec("parquet")
+    val spec = SourceLocationSpec("parquet", new Path("."))
     spec.identifier should be ("parquet")
     spec.dataspace should be ("source")
+    spec.sourcePath should be (new Path("."))
   }
 
   test("IndexLocationSpec - catalog spec") {
-    val spec = CatalogLocationSpec("parquet")
+    val spec = CatalogLocationSpec("parquet", new Path("."))
     spec.identifier should be ("parquet")
     spec.dataspace should be ("catalog")
+    spec.sourcePath should be (new Path("."))
   }
 
   test("IndexLocationSpec - toString") {
-    TestLocationSpec("identifier", "dataspace").toString should be ("[dataspace/identifier]")
-    SourceLocationSpec("parquet").toString should be ("[source/parquet]")
-    CatalogLocationSpec("parquet").toString should be ("[catalog/parquet]")
+    TestLocationSpec("identifier", "dataspace", new Path("/tmp/test")).toString should be (
+      "[dataspace/identifier, source=/tmp/test]")
+    SourceLocationSpec("parquet", new Path("/tmp/source")).toString should be (
+      "[source/parquet, source=/tmp/source]")
+    CatalogLocationSpec("parquet", new Path("/tmp/catalog")).toString should be (
+      "[catalog/parquet, source=/tmp/catalog]")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/IndexedDataSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/IndexedDataSourceSuite.scala
@@ -130,8 +130,8 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("resolveRelation - fail if index directory does not contain SUCCESS file") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val spec = SourceLocationSpec("test")
-      mkdirs(metastore.location(spec, dir))
+      val spec = SourceLocationSpec("test", dir)
+      mkdirs(metastore.location(spec))
       val source = IndexedDataSource(
         metastore,
         classOf[TestMetastoreSupport].getCanonicalName,
@@ -147,8 +147,8 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("resolveRelation - return HadoopFsRelation for metastore support") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val spec = SourceLocationSpec("test")
-      val location = metastore.location(spec, dir)
+      val spec = SourceLocationSpec("test", dir)
+      val location = metastore.location(spec)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
       val source = IndexedDataSource(
@@ -214,7 +214,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("existsIndex - return false if index directory does not contain SUCCESS file") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location(SourceLocationSpec("test"), dir)
+      val path = metastore.location(SourceLocationSpec("test", dir))
       // create directory in index metastore, do not mark it as success
       mkdirs(path)
       val source = IndexedDataSource(
@@ -228,7 +228,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("existsIndex - return false if table path does not exist") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location(SourceLocationSpec("test"), dir)
+      val path = metastore.location(SourceLocationSpec("test", dir))
       // check index existince for non-existent table path
       val source = IndexedDataSource(
         metastore,
@@ -241,7 +241,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("existsIndex - invoke metastore support method") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location(SourceLocationSpec("test"), dir)
+      val path = metastore.location(SourceLocationSpec("test", dir))
       // create directory in index metastore and mark it as success to check index existence
       mkdirs(path)
       Metastore.markSuccess(fs, path)
@@ -270,7 +270,7 @@ class IndexedDataSourceSuite extends UnitTestSuite with SparkLocal with TestMeta
   test("deleteIndex - invoke metastore support method") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test")
-      val path = metastore.location(SourceLocationSpec("test"), dir)
+      val path = metastore.location(SourceLocationSpec("test", dir))
       // create directory in index metastore, otherwise delete method is no-op
       mkdirs(path)
       val source = IndexedDataSource(

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -185,14 +185,13 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, new Path("/tmp/table"))
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.Append) {
-        case (status, isAppend) =>
-          triggered = true
-          status.isDirectory should be (true)
-          status.getPermission should be (Metastore.METASTORE_PERMISSION)
-          isAppend should be (false)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
+      metastore.create(spec, SaveMode.Append) { case (status, isAppend) =>
+        triggered = true
+        status.isDirectory should be (true)
+        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        isAppend should be (false)
       }
       triggered should be (true)
       Metastore.checkSuccessFile(fs, location) should be (true)
@@ -203,14 +202,13 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, new Path("/tmp/table"))
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.Overwrite) {
-        case (status, isAppend) =>
-          triggered = true
-          status.isDirectory should be (true)
-          status.getPermission should be (Metastore.METASTORE_PERMISSION)
-          isAppend should be (false)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
+      metastore.create(spec, SaveMode.Overwrite) { case (status, isAppend) =>
+        triggered = true
+        status.isDirectory should be (true)
+        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        isAppend should be (false)
       }
       triggered should be (true)
       Metastore.checkSuccessFile(fs, location) should be (true)
@@ -221,14 +219,13 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, new Path("/tmp/table"))
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.ErrorIfExists) {
-        case (status, isAppend) =>
-          triggered = true
-          status.isDirectory should be (true)
-          status.getPermission should be (Metastore.METASTORE_PERMISSION)
-          isAppend should be (false)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
+      metastore.create(spec, SaveMode.ErrorIfExists) { case (status, isAppend) =>
+        triggered = true
+        status.isDirectory should be (true)
+        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        isAppend should be (false)
       }
       triggered should be (true)
       Metastore.checkSuccessFile(fs, location) should be (true)
@@ -239,14 +236,13 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, new Path("/tmp/table"))
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.Ignore) {
-        case (status, isAppend) =>
-          triggered = true
-          status.isDirectory should be (true)
-          status.getPermission should be (Metastore.METASTORE_PERMISSION)
-          isAppend should be (false)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
+      metastore.create(spec, SaveMode.Ignore) { case (status, isAppend) =>
+        triggered = true
+        status.isDirectory should be (true)
+        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        isAppend should be (false)
       }
       triggered should be (true)
       Metastore.checkSuccessFile(fs, location) should be (true)
@@ -257,18 +253,17 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       // create directory and existing file
       touch(path / "metadata")
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.Append) {
-        case (status, isAppend) =>
-          triggered = true
-          status.isDirectory should be (true)
-          status.getPermission should be (Metastore.METASTORE_PERMISSION)
-          isAppend should be (true)
-          // original file should still exist in the folder
-          metastore.fs.exists(path / "metadata") should be (true)
+      metastore.create(spec, SaveMode.Append) { case (status, isAppend) =>
+        triggered = true
+        status.isDirectory should be (true)
+        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        isAppend should be (true)
+        // original file should still exist in the folder
+        metastore.fs.exists(path / "metadata") should be (true)
       }
       triggered should be (true)
       Metastore.checkSuccessFile(fs, path) should be (true)
@@ -279,18 +274,17 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       // create directory and existing file
       touch(path / "metadata")
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.Overwrite) {
-        case (status, isAppend) =>
-          triggered = true
-          status.isDirectory should be (true)
-          status.getPermission should be (Metastore.METASTORE_PERMISSION)
-          isAppend should be (false)
-          // original file should be deleted
-          metastore.fs.exists(path / "metadata") should be (false)
+      metastore.create(spec, SaveMode.Overwrite) { case (status, isAppend) =>
+        triggered = true
+        status.isDirectory should be (true)
+        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        isAppend should be (false)
+        // original file should be deleted
+        metastore.fs.exists(path / "metadata") should be (false)
       }
       triggered should be (true)
       Metastore.checkSuccessFile(fs, path) should be (true)
@@ -300,11 +294,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("create - existing path, ErrorIfExists mode") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       mkdirs(path)
       val err = intercept[IOException] {
-        metastore.create(spec, new Path("/tmp/table"), SaveMode.ErrorIfExists) {
+        metastore.create(spec, SaveMode.ErrorIfExists) {
           case (status, isAppend) => // do nothing
         }
       }
@@ -316,11 +310,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       mkdirs(path)
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.Ignore) {
-        case (status, isAppend) => triggered = true
+      metastore.create(spec, SaveMode.Ignore) { case (status, isAppend) =>
+        triggered = true
       }
       // should not invoke closure
       triggered should be (false)
@@ -330,15 +324,14 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("create - delete directory when fails, mode is not Append") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
       var path: Path = null
       val err = intercept[IllegalStateException] {
-        metastore.create(spec, new Path("/tmp/table"), SaveMode.Overwrite) {
-          case (status, isAppend) =>
-            // path should exist before exception is thrown
-            path = status.getPath
-            metastore.fs.exists(path) should be (true)
-            throw new IllegalStateException("Test failure")
+        metastore.create(spec, SaveMode.Overwrite) { case (status, isAppend) =>
+          // path should exist before exception is thrown
+          path = status.getPath
+          metastore.fs.exists(path) should be (true)
+          throw new IllegalStateException("Test failure")
         }
       }
       err.getMessage should be ("Test failure")
@@ -350,17 +343,16 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       // create folder to trigger append mode
-      val spec = SourceLocationSpec("identifier")
-      mkdirs(metastore.location(spec, new Path("/tmp/table")))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      mkdirs(metastore.location(spec))
       var path: Path = null
       val err = intercept[IllegalStateException] {
-        metastore.create(spec, new Path("/tmp/table"), SaveMode.Append) {
-          case (status, isAppend) =>
-            // path should exist before exception is thrown
-            path = status.getPath
-            isAppend should be (true)
-            metastore.fs.exists(path) should be (true)
-            throw new IllegalStateException("Test failure")
+        metastore.create(spec, SaveMode.Append) { case (status, isAppend) =>
+          // path should exist before exception is thrown
+          path = status.getPath
+          isAppend should be (true)
+          metastore.fs.exists(path) should be (true)
+          throw new IllegalStateException("Test failure")
         }
       }
       err.getMessage should be ("Test failure")
@@ -372,12 +364,12 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("create - invalidate cache before creating index") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       metastore.cache.put(path, new TestIndexCatalog())
       metastore.cache.asMap.size should be (1)
 
-      metastore.create(spec, new Path("/tmp/table"), SaveMode.ErrorIfExists) {
+      metastore.create(spec, SaveMode.ErrorIfExists) {
         case (status, isAppend) => // no-op
       }
       metastore.cache.asMap.size should be (0)
@@ -393,7 +385,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      metastore.delete(SourceLocationSpec("identifier"), new Path("/tmp/table")) {
+      metastore.delete(SourceLocationSpec("identifier", new Path("/tmp/table"))) {
         case status => triggered = true
       }
       // should not invoke closure
@@ -405,11 +397,11 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       var triggered = false
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       mkdirs(path)
-      metastore.delete(spec, new Path("/tmp/table")) {
-        case status => triggered = true
+      metastore.delete(spec) { case status =>
+        triggered = true
       }
       triggered should be (true)
       metastore.fs.exists(path) should be (false)
@@ -419,13 +411,13 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("delete - invalidate cache before deleting index") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       metastore.cache.put(path, new TestIndexCatalog())
       metastore.cache.asMap.size should be (1)
 
       mkdirs(path)
-      metastore.delete(spec, new Path("/tmp/table")) {
+      metastore.delete(spec) {
         case status => // no-op
       }
       metastore.fs.exists(path) should be (false)
@@ -438,10 +430,10 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("delete - do not invalidate cache if index does not exist") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
-      val path = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val path = metastore.location(spec)
       metastore.cache.put(path, new TestIndexCatalog())
-      metastore.delete(spec, new Path("/tmp/table")) {
+      metastore.delete(spec) {
         case status => // no-op
       }
       // metastore cache should still contain above entry
@@ -458,7 +450,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
       val err = intercept[IOException] {
-        metastore.load(SourceLocationSpec("identifier"), new Path("/tmp/table")) {
+        metastore.load(SourceLocationSpec("identifier", new Path("/tmp/table"))) {
           case status => new TestIndexCatalog()
         }
       }
@@ -469,12 +461,12 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("load - existing directory without SUCCESS file") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
       mkdirs(location)
       val err = intercept[IOException] {
-        metastore.load(spec, new Path("/tmp/table")) {
-          case status => new TestIndexCatalog()
+        metastore.load(spec) { case status =>
+          new TestIndexCatalog()
         }
       }
       assert(err.getMessage.contains("Possibly corrupt index, could not find success mark"))
@@ -484,15 +476,14 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("load - existing directory") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, new Path("/tmp/table"))
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
       var triggered = false
-      metastore.load(spec, new Path("/tmp/table")) {
-        case status =>
-          triggered = true
-          new TestIndexCatalog()
+      metastore.load(spec) { case status =>
+        triggered = true
+        new TestIndexCatalog()
       }
       triggered should be (true)
       // check that cache also contains entry
@@ -503,16 +494,15 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("load - use cache instead of reading from disk") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = new Path("/tmp/table")
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, path)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
 
-      val catalog1 = metastore.load(spec, path) {
+      val catalog1 = metastore.load(spec) {
         case status => new TestIndexCatalog()
       }
-      val catalog2 = metastore.load(spec, path) {
+      val catalog2 = metastore.load(spec) {
         case status =>
           throw new IllegalStateException("Expected to use cache, failed to load entry")
       }
@@ -529,31 +519,29 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("exists - index path does not exist") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = new Path("/tmp/table")
-      metastore.exists(SourceLocationSpec("identifier"), path) should be (false)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      metastore.exists(spec) should be (false)
     }
   }
 
   test("exists - directory exists, but no SUCCESS file") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = new Path("/tmp/table")
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, path)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
       mkdirs(location)
-      metastore.exists(spec, path) should be (false)
+      metastore.exists(spec) should be (false)
     }
   }
 
   test("exists - directory and SUCCESS file both exist") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val path = new Path("/tmp/table")
-      val spec = SourceLocationSpec("identifier")
-      val location = metastore.location(spec, path)
+      val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
+      val location = metastore.location(spec)
       mkdirs(location)
       Metastore.markSuccess(fs, location)
-      metastore.exists(spec, path) should be (true)
+      metastore.exists(spec) should be (true)
     }
   }
 
@@ -564,8 +552,8 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - local fully-qualified path") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("test")
-      metastore.location(spec, new Path("file:/tmp/path")) should be (
+      val spec = SourceLocationSpec("test", new Path("file:/tmp/path"))
+      metastore.location(spec) should be (
         new Path("file:" + s"$dir" / spec.dataspace / spec.identifier / "file" / "tmp" / "path")
       )
     }
@@ -574,8 +562,8 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - hdfs fully-qualified path") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("test")
-      metastore.location(spec, new Path("hdfs://sandbox:8020/tmp/path")) should be (
+      val spec = SourceLocationSpec("test", new Path("hdfs://sandbox:8020/tmp/path"))
+      metastore.location(spec) should be (
         new Path("file:" + s"$dir" / spec.dataspace / spec.identifier / "hdfs" / "tmp" / "path")
       )
     }
@@ -584,8 +572,8 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - non-qualified path part") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("test")
-      metastore.location(spec, new Path("tmp/something")) should be (
+      val spec = SourceLocationSpec("test", new Path("tmp/something"))
+      metastore.location(spec) should be (
         new Path(
           "file:" + s"$dir" / spec.dataspace / spec.identifier / "file" / "tmp" / "something")
       )
@@ -595,9 +583,9 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
   test("location - empty path") {
     withTempDir(Metastore.METASTORE_PERMISSION) { dir =>
       val metastore = testMetastore(spark, dir)
-      val spec = SourceLocationSpec("test")
       val err = intercept[IllegalArgumentException] {
-        metastore.location(spec, new Path(""))
+        val spec = SourceLocationSpec("test", new Path(""))
+        metastore.location(spec)
       }
       assert(err.getMessage.contains("Can not create a Path from an empty string"))
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
@@ -268,8 +268,8 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
 
         val support = new ParquetMetastoreSupport()
-        val spec = SourceLocationSpec(support.identifier)
-        val location = metastore.location(spec, dir / "table")
+        val spec = SourceLocationSpec(support.identifier, dir / "table")
+        val location = metastore.location(spec)
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
           asInstanceOf[ParquetIndexCatalog]
@@ -303,8 +303,8 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
 
         val support = new ParquetMetastoreSupport()
-        val spec = SourceLocationSpec(support.identifier)
-        val location = metastore.location(spec, dir / "table")
+        val spec = SourceLocationSpec(support.identifier, dir / "table")
+        val location = metastore.location(spec)
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
           asInstanceOf[ParquetIndexCatalog]
@@ -339,8 +339,8 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         spark.index.create.indexBy("id", "str").parquet(dir.toString / "table")
 
         val support = new ParquetMetastoreSupport()
-        val spec = SourceLocationSpec(support.identifier)
-        val location = metastore.location(spec, dir / "table")
+        val spec = SourceLocationSpec(support.identifier, dir / "table")
+        val location = metastore.location(spec)
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
           asInstanceOf[ParquetIndexCatalog]


### PR DESCRIPTION
This PR updates `IndexLocationSpec` to include source path. Before this patch, path was propagated separately into metastore, after - we include it into location spec when creating it. Therefore metastore only requires location spec to create/load/delete/check index, which makes it easier to extend it with metadata, etc.