### PR TITLE
Update metastore permissions

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/Metastore.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/Metastore.scala
@@ -268,9 +268,9 @@ private[sql] class Metastore(
 object Metastore {
   // default metastore directory name
   val DEFAULT_METASTORE_DIR = "index_metastore"
-  // permission mode "rwxrw-rw-"
+  // permission mode "rwxr--r--"
   val METASTORE_PERMISSION =
-    new FsPermission(FsAction.ALL, FsAction.READ_WRITE, FsAction.READ_WRITE)
+    new FsPermission(FsAction.ALL, FsAction.READ, FsAction.READ)
   // default success mark for index directory
   val METASTORE_SUCCESS_FILE = "_SUCCESS"
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -109,7 +109,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       val err = intercept[IllegalStateException] {
         new Metastore(spark, conf)
       }
-      assert(err.getMessage.contains("Expected directory with rwxrw-rw-"))
+      assert(err.getMessage.contains("Expected directory with rwxr--r--"))
       assert(err.getMessage.contains("r--r--r--"))
     }
   }


### PR DESCRIPTION
This PR updates metastore permissions from `rwxrw-rw-` to `rwxr--r--`, which is more suitable when it is manually created, and also avoids error in #67.

Fixes #67.