### PR TITLE
Index number of partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ other Spark configuration or add them to `spark-defaults.conf` file.
 | `spark.sql.index.parquet.filter.type` | When filter statistics enabled, select type of statistics to use when creating index (`bloom`, `dict`) | `bloom`
 | `spark.sql.index.parquet.filter.eagerLoading` | When set to `true`, read and load all filter statistics in memory the first time catalog is resolved, otherwise load them lazily as needed when evaluating predicate (`true`, `false`) | `false`
 | `spark.sql.index.createIfNotExists` | When set to true, create index if one does not exist in metastore for the table, and will use all available columns for indexing (`true`, `false`) | `false`
+| `spark.sql.index.partitions` | When creating index uses this number of partitions. If value is non-positive or not provided then uses `sc.defaultParallelism * 3` or `spark.sql.shuffle.partitions` configuration value, whichever is smaller | `min(sc.defaultParallelism * 3, shuffle partitions)`
 
 ## Example
 

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -33,6 +33,13 @@ object IndexConf {
     booleanConf.
     createWithDefault(false)
 
+  val NUM_PARTITIONS = SQLConfigBuilder("spark.sql.index.partitions").
+    doc("When creating index uses this number of partitions. If value is non-positive or not " +
+      "provided then uses `sc.defaultParallelism * 3` or `spark.sql.shuffle.partitions` " +
+      "configuration value, whichever is smaller").
+    intConf.
+    createWithDefault(0)
+
   val PARQUET_FILTER_STATISTICS_ENABLED =
     SQLConfigBuilder("spark.sql.index.parquet.filter.enabled").
     doc("When set to true, writes filter statistics for indexed columns when creating table " +
@@ -75,6 +82,8 @@ class IndexConf private[sql](val sqlConf: SQLConf) {
   def parquetFilterEagerLoading: Boolean = getConf(PARQUET_FILTER_STATISTICS_EAGER_LOADING)
 
   def createIfNotExists: Boolean = getConf(CREATE_IF_NOT_EXISTS)
+
+  def numPartitions: Int = getConf(NUM_PARTITIONS)
 
   /** ********************** IndexConf functionality methods ************ */
 


### PR DESCRIPTION
This PR adds option `spark.sql.index.partitions` to provide number of partitions that should be used when creating index or other `sc.parallelize` code. Also changes default value to be `sc.defaultParallelism * 3` instead of 2.