### PR TITLE
Fix error message when no columns found in schema

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -199,10 +199,9 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
       // fetch specified columns, inferred fields should be the same as requested columns
       val inferredSchema = StructType(fileStruct.filter { field => columns.contains(field.name) })
       columns.foreach { name =>
-        val containsField = inferredSchema.exists { _.name == name }
-        if (!containsField) {
-          throw new IllegalArgumentException("Failed to select indexed columns. " +
-            s"Column $name does not exist in inferred schema ${inferredSchema.simpleString}")
+        if (!inferredSchema.exists { _.name == name }) {
+          throw new IllegalArgumentException(s"Failed to select indexed column '$name' in " +
+            s"inferred/original schema ${fileStruct.simpleString}")
         }
       }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtils.scala
@@ -75,7 +75,7 @@ object ParquetSchemaUtils {
     schema.getFields.asScala.map { field =>
       if (uniqueColumns.contains(field.getName)) {
         throw new IllegalArgumentException(s"""
-          | Found field [$field] with duplicate column name ${field.getName}.
+          | Found field [$field] with duplicate column name '${field.getName}'.
           | Schema $schema
           | This situation is currently not supported, ensure that names of all top level columns
           | in schema are unique""".stripMargin)

--- a/src/test/scala/org/apache/spark/sql/IndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/IndexSuite.scala
@@ -97,8 +97,8 @@ class IndexSuite extends UnitTestSuite with SparkLocal {
         val err = intercept[IllegalArgumentException] {
           spark.index.create.indexBy("str", "id").parquet(dir.toString / "test")
         }
-        assert(err.getMessage.contains("Failed to select indexed columns. Column str does not " +
-          "exist in inferred schema struct<id:bigint>"))
+        assert(err.getMessage.contains("Failed to select indexed column 'str' in " +
+          "inferred/original schema struct<id:bigint>"))
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaUtilsSuite.scala
@@ -148,7 +148,7 @@ class ParquetSchemaUtilsSuite extends UnitTestSuite {
     val err = intercept[IllegalArgumentException] {
       ParquetSchemaUtils.topLevelUniqueColumns(schema)
     }
-    assert(err.getMessage.contains("[required int32 id] with duplicate column name id"))
+    assert(err.getMessage.contains("[required int32 id] with duplicate column name 'id'"))
   }
 
   test("merge - two identical schemas") {


### PR DESCRIPTION
This PR fixes error message in `ParquetMetastoreSupport`, so now it shows the original schema and indexed column that does not exist - easier to check original schema. Also wraps column names in messages with quotes.

Closes #71.