### PR TITLE
Improve pruneIndexedPartitions by using futures

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -19,9 +19,8 @@ package org.apache.spark.sql.execution.datasources.parquet
 import java.io.IOException
 import java.util.Arrays
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
-import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.{FileStatus, Path}


### PR DESCRIPTION
This PR updates code for sequential resolution of `foldFilter` by using futures and executing `resolveSupported` method in parallel for each file in Parquet partition; partitions are still resolved sequentially. 

Manual testing shows about 1.5-2x performance improvement when filtering index partitions (with large portion of files being scanned). But it also introduces a little bit of overhead when filtering partitions on cached index (20ms vs 35ms). This approach is similar to eager loading.

Benchmarks:
Each test includes cold start and warm start (same query but all necessary column filters have been loaded on previous step)

### Dataset with 1000 partitions
#### Search 1 record
`master`
```
Applying index filters: IsNotNull(strid),EqualTo(strid,35732)
Filtered indexed partitions in 438.53 ms
Post-Scan filters: isnotnull(strid#13),(strid#13 = 35732)

Applying index filters: IsNotNull(strid),EqualTo(strid,35732)
Filtered indexed partitions in 37.332 ms
Post-Scan filters: isnotnull(strid#28),(strid#28 = 35732)
```

`filter-resolution`
```
Applying index filters: IsNotNull(strid),EqualTo(strid,35732)
Filtered indexed partitions in 365.721 ms
Post-Scan filters: isnotnull(strid#7),(strid#7 = 35732)

Applying index filters: IsNotNull(strid),EqualTo(strid,35732)
Filtered indexed partitions in 39.74 ms
Post-Scan filters: isnotnull(strid#22),(strid#22 = 35732)
```

#### Search all records
`master`
```
Applying index filters: IsNotNull(col4),EqualTo(col4,value)
Filtered indexed partitions in 641.424 ms
Post-Scan filters: isnotnull(col4#11),(col4#11 = value)
```

`filter-resolution`
```
Applying index filters: IsNotNull(col4),EqualTo(col4,value)
Filtered indexed partitions in 390.783 ms
Post-Scan filters: isnotnull(col4#11),(col4#11 = value)
```

### Dataset with 400 partitions
#### Search 1 record
`master`
```
Applying index filters: IsNotNull(code),EqualTo(code,339382)
Filtered indexed partitions in 1178.762 ms
Post-Scan filters: isnotnull(code#8),(code#8 = 339382)

Applying index filters: IsNotNull(code),EqualTo(code,339382)
Filtered indexed partitions in 17.909 ms
Post-Scan filters: isnotnull(code#21),(code#21 = 339382)
```

`filter-resolution`
```
Applying index filters: IsNotNull(code),EqualTo(code,339382)
Filtered indexed partitions in 509.551 ms
Post-Scan filters: isnotnull(code#8),(code#8 = 339382)

Applying index filters: IsNotNull(code),EqualTo(code,339382)
Filtered indexed partitions in 12.801 ms
Post-Scan filters: isnotnull(code#21),(code#21 = 339382)
```

Closes #56.