### PR TITLE
Spark 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
   - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
-  - sbt ++$TRAVIS_SCALA_VERSION assembly
   - sbt ++$TRAVIS_SCALA_VERSION package
   - ./bin/setup-spark $TEST_SPARK_RELEASE $HOME/.cache/spark-versions
   - SPARK_HOME=$HOME/.cache/spark-versions/$TEST_SPARK_RELEASE ./bin/run-python-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ matrix:
   include:
     - jdk: oraclejdk8
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0"
+      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.7"
     - jdk: oraclejdk8
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1"
+      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1-bin-hadoop2.7"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
   - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION package
-  - ./bin/setup-spark $TEST_SPARK_RELEASE $HOME/.cache/spark-versions
+  - ./bin/setup-spark $TEST_SPARK_VERSION $TEST_SPARK_RELEASE $HOME/.cache/spark-versions
   - SPARK_HOME=$HOME/.cache/spark-versions/$TEST_SPARK_RELEASE ./bin/run-python-tests
 after_success:
   - sbt coverageReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ matrix:
   include:
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.1.0" TEST_SPARK_RELEASE="spark-2.1.0-bin-hadoop2.6"
+      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
     - jdk: openjdk7
+      scala: 2.11.7
+      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1-bin-hadoop2.6"
+    - jdk: oraclejdk8
       scala: 2.11.7
       env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
     - jdk: oraclejdk8
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
+      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1-bin-hadoop2.6"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ cache:
     - $HOME/.cache/spark-versions
 matrix:
   include:
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1-bin-hadoop2.6"
     - jdk: oraclejdk8
       scala: 2.11.7
       env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,14 @@ cache:
 matrix:
   include:
     - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_SPARK_VERSION="2.0.0" TEST_SPARK_RELEASE="NA"
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_SPARK_VERSION="2.0.1" TEST_SPARK_RELEASE="NA"
+      scala: 2.11.7
+      env: TEST_SPARK_VERSION="2.1.0" TEST_SPARK_RELEASE="spark-2.1.0-bin-hadoop2.6"
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.0.0" TEST_SPARK_RELEASE="spark-2.0.0-bin-hadoop2.6"
-    - jdk: openjdk7
+      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
+    - jdk: oraclejdk8
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.0.1" TEST_SPARK_RELEASE="spark-2.0.1-bin-hadoop2.6"
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.0.2" TEST_SPARK_RELEASE="spark-2.0.2-bin-hadoop2.6"
+      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
   include:
     - jdk: oraclejdk8
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0-bin-hadoop2.6"
+      env: TEST_SPARK_VERSION="2.2.0" TEST_SPARK_RELEASE="spark-2.2.0"
     - jdk: oraclejdk8
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1-bin-hadoop2.6"
+      env: TEST_SPARK_VERSION="2.2.1" TEST_SPARK_RELEASE="spark-2.2.1"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"

--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ Currently only these types are supported for indexed columns:
 - Scala 2.11.x
 - JDK 8+
 
-> Previous versions have support for Scala 2.10.x and JDK 7, see README for corresponding tag or branch
->
-> Note that you could still build it manually for different Java/Scala versions
+> Previous versions have support for Scala 2.10.x and JDK 7, see README for corresponding tag or
+> branch. See build section to compile for desired Java/Scala versions.
 
 ## Linking
 The `parquet-index` package can be added to Spark by using the `--packages` command line option.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Currently only these types are supported for indexed columns:
 | 2.0.2 | [0.2.3](http://spark-packages.org/package/lightcopy/parquet-index) |
 | 2.1.x | Not supported |
 
+- Scala 2.10.x/2.11.x
+- JDK 8+
+
 ## Linking
 The `parquet-index` package can be added to Spark by using the `--packages` command line option.
 For example, run this to include it when starting `spark-shell` (Scala 2.11.x):

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Currently only these types are supported for indexed columns:
 - JDK 8+
 
 > Previous versions have support for Scala 2.10.x and JDK 7, see README for corresponding tag or branch
+>
+> Note that you could still build it manually for different Java/Scala versions
 
 ## Linking
 The `parquet-index` package can be added to Spark by using the `--packages` command line option.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Currently only these types are supported for indexed columns:
 | 2.0.2 | [0.2.3](http://spark-packages.org/package/lightcopy/parquet-index) |
 | 2.1.x | Not supported |
 
-- Scala 2.10.x/2.11.x
+- Scala 2.11.x
 - JDK 8+
+
+> Previous versions have support for Scala 2.10.x and JDK 7, see README for corresponding tag or branch
 
 ## Linking
 The `parquet-index` package can be added to Spark by using the `--packages` command line option.
@@ -73,7 +75,6 @@ Or for `pyspark` to use Python API (see section below):
 ```shell
 $SPARK_HOME/bin/pyspark --packages lightcopy:parquet-index:0.2.3-s_2.11
 ```
-Change to `lightcopy:parquet-index:0.2.3-s_2.10` for Scala 2.10.x
 
 ## Options
 Currently supported options, use `--conf key=value` on a command line to provide options similar to

--- a/bin/setup-spark
+++ b/bin/setup-spark
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Test only hadoop2.7 distributions
+# Test only hadoop2.7 distributions, should be in sync with build.sbt
 SPARK_RELEASE=$1
 CACHE_DIR=$2
 

--- a/bin/setup-spark
+++ b/bin/setup-spark
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-# Test only hadoop2.7 distributions, should be in sync with build.sbt
-SPARK_RELEASE=$1
-CACHE_DIR=$2
+SPARK_VERSION=$1
+SPARK_RELEASE=$2
+CACHE_DIR=$3
+
+if [[ -z "$SPARK_VERSION" ]]; then
+  echo "Spark version is required, e.g. 2.2.0"
+  exit 1
+fi
 
 if [[ -z "$SPARK_RELEASE" ]]; then
-  echo "Spark version is invalid: $SPARK_RELEASE, must follow pattern spark-x.y.z"
+  echo "Spark version is invalid: $SPARK_RELEASE, must follow pattern spark-x.y.z-bin-hadoopX.Y"
   exit 1
 elif [[ "$SPARK_RELEASE" == "NA" ]]; then
   # If Spark release is set to NA, then release is not available, and we ignore setup
@@ -29,16 +34,15 @@ else
   mkdir -p $CACHE_DIR
 fi
 
-SPARK_VERSION="$SPARK_RELEASE-bin-hadoop2.7.tgz"
-SPARK_VERSION_DIR="$CACHE_DIR/$SPARK_VERSION"
-SPARK_VERSION_URL="http://www-us.apache.org/dist/spark/$SPARK_RELEASE/$SPARK_VERSION"
+SPARK_VERSION_DIR="$CACHE_DIR/$SPARK_RELEASE"
+SPARK_VERSION_URL="http://www-us.apache.org/dist/spark/spark-$SPARK_VERSION/$SPARK_RELEASE.tgz"
 
 # Check if cached version is already available
 if [[ -d "$SPARK_VERSION_DIR" ]]; then
   echo "Using existing Spark cache $SPARK_VERSION_DIR"
 else
   echo "Cache is not found for $SPARK_VERSION_DIR"
-  echo "Downloading Spark version $SPARK_VERSION from $SPARK_VERSION_URL"
+  echo "Downloading Spark version $SPARK_RELEASE from $SPARK_VERSION_URL"
   # Remove tar archive that might have been left after unsuccessful download
   rm -f $SPARK_VERSION_DIR.tgz
   curl -L "$SPARK_VERSION_URL" > "$SPARK_VERSION_DIR.tgz"

--- a/bin/setup-spark
+++ b/bin/setup-spark
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+# Test only hadoop2.7 distributions
 SPARK_RELEASE=$1
 CACHE_DIR=$2
 
 if [[ -z "$SPARK_RELEASE" ]]; then
-  echo "Spark version is invalid: $SPARK_RELEASE, must follow pattern spark-x.y.z-bin-hadoopX.Y"
+  echo "Spark version is invalid: $SPARK_RELEASE, must follow pattern spark-x.y.z"
   exit 1
 elif [[ "$SPARK_RELEASE" == "NA" ]]; then
   # If Spark release is set to NA, then release is not available, and we ignore setup
@@ -29,7 +30,7 @@ else
 fi
 
 SPARK_VERSION_DIR="$CACHE_DIR/$SPARK_RELEASE"
-SPARK_VERSION_URL="http://d3kbcqa49mib13.cloudfront.net/$SPARK_RELEASE.tgz"
+SPARK_VERSION_URL="http://www-us.apache.org/dist/spark/$SPARK_RELEASE/$SPARK_RELEASE-bin-hadoop2.7.tgz"
 
 # Check if cached version is already available
 if [[ -d "$SPARK_VERSION_DIR" ]]; then

--- a/bin/setup-spark
+++ b/bin/setup-spark
@@ -29,15 +29,16 @@ else
   mkdir -p $CACHE_DIR
 fi
 
-SPARK_VERSION_DIR="$CACHE_DIR/$SPARK_RELEASE"
-SPARK_VERSION_URL="http://www-us.apache.org/dist/spark/$SPARK_RELEASE/$SPARK_RELEASE-bin-hadoop2.7.tgz"
+SPARK_VERSION="$SPARK_RELEASE-bin-hadoop2.7.tgz"
+SPARK_VERSION_DIR="$CACHE_DIR/$SPARK_VERSION"
+SPARK_VERSION_URL="http://www-us.apache.org/dist/spark/$SPARK_RELEASE/$SPARK_VERSION"
 
 # Check if cached version is already available
 if [[ -d "$SPARK_VERSION_DIR" ]]; then
   echo "Using existing Spark cache $SPARK_VERSION_DIR"
 else
   echo "Cache is not found for $SPARK_VERSION_DIR"
-  echo "Downloading Spark release $SPARK_RELEASE from $SPARK_VERSION_URL"
+  echo "Downloading Spark version $SPARK_VERSION from $SPARK_VERSION_URL"
   # Remove tar archive that might have been left after unsuccessful download
   rm -f $SPARK_VERSION_DIR.tgz
   curl -L "$SPARK_VERSION_URL" > "$SPARK_VERSION_DIR.tgz"

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 spName := "lightcopy/parquet-index"
 
-val defaultSparkVersion = "2.0.1"
+val defaultSparkVersion = "2.2.0"
 
 sparkVersion := sys.props.getOrElse("spark.testVersion", defaultSparkVersion)
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val defaultSparkVersion = "2.2.0"
 
 sparkVersion := sys.props.getOrElse("spark.testVersion", defaultSparkVersion)
 
-val defaultHadoopVersion = "2.6.0"
+val defaultHadoopVersion = "2.7.0"
 
 val hadoopVersion = settingKey[String]("The version of Hadoop to test against.")
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexSourceStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexSourceStrategy.scala
@@ -16,33 +16,24 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import scala.collection.mutable.ArrayBuffer
-
-import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.DataSourceScanExec
-import org.apache.spark.sql.execution.DataSourceScanExec.{INPUT_PATHS, PUSHED_FILTERS}
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 
 object IndexSourceStrategy extends Strategy with Logging {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case PhysicalOperation(projects, filters,
       l @ LogicalRelation(fsRelation: HadoopFsRelation, _, table))
-      if fsRelation.location.isInstanceOf[MetastoreIndexCatalog] =>
+      if fsRelation.location.isInstanceOf[MetastoreIndex] =>
 
-      val sparkSession = fsRelation.sparkSession
-      val catalog = fsRelation.location.asInstanceOf[MetastoreIndexCatalog]
-      val resolver = sparkSession.sessionState.analyzer.resolver
+      val catalog = fsRelation.location.asInstanceOf[MetastoreIndex]
+      val resolver = fsRelation.sparkSession.sessionState.analyzer.resolver
 
-      // Split filters on partitioning filters, index filters and data filters
       val filterSet = ExpressionSet(filters)
-
       // The attribute name of predicate could be different than the one in schema in case of
       // case insensitive, we should change them to match the one in schema, so we do not need to
       // worry about case sensitivity anymore.
@@ -53,12 +44,11 @@ object IndexSourceStrategy extends Strategy with Logging {
         }
       }
 
-      // Resolve partitioning columns and extract filters
       val partitionColumns = l.resolve(fsRelation.partitionSchema, resolver)
       val partitionSet = AttributeSet(partitionColumns)
-      val partitionKeyFilters = ExpressionSet(
-        normalizedFilters.filter(_.references.subsetOf(partitionSet)))
-      logInfo(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
+      val partitionKeyFilters =
+        ExpressionSet(normalizedFilters.filter(_.references.subsetOf(partitionSet)))
+      logDebug(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
 
       // Resolve index schema and extract index filters
       // Filters will only be applied for indexed columns that allow predicate to be separately
@@ -71,6 +61,9 @@ object IndexSourceStrategy extends Strategy with Logging {
       val indexSet = AttributeSet(indexColumns)
       val indexFilters = normalizedFilters.filter(_.references.subsetOf(indexSet)).
         flatMap(DataSourceStrategy.translateFilter)
+      // Hack to propagate filters into FileSourceScanExec instead of copying a lot of code to
+      // add index filters, catalog will reset filters every time this method is called
+      catalog.setIndexFilters(indexFilters)
       logInfo(s"Applying index filters: ${indexFilters.mkString(",")}")
       if (indexFilters.isEmpty) {
         logWarning(s"Cannot extract predicate for indexed columns $indexColumns from normalized " +
@@ -80,133 +73,36 @@ object IndexSourceStrategy extends Strategy with Logging {
           "'Or' make sure that both branches contain indexed columns")
       }
 
-      // select relevant partitions based on index filters and partition keys
-      val selectedPartitions =
-        catalog.listFilesWithIndexSupport(partitionKeyFilters.toSeq, indexFilters)
-
       val dataColumns = l.resolve(fsRelation.dataSchema, resolver)
+
       // Partition keys are not available in the statistics of the files.
       val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)
 
       // Predicates with both partition keys and attributes need to be evaluated after the scan.
-      val afterScanFilters = filterSet -- partitionKeyFilters
-      logInfo(s"Post-Scan filters: ${afterScanFilters.mkString(",")}")
+      val afterScanFilters = filterSet -- partitionKeyFilters.filter(_.references.nonEmpty)
+      logInfo(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
 
       val filterAttributes = AttributeSet(afterScanFilters)
       val requiredExpressions: Seq[NamedExpression] = filterAttributes.toSeq ++ projects
       val requiredAttributes = AttributeSet(requiredExpressions)
 
-      val readDataColumns = dataColumns.
-        filter(requiredAttributes.contains).
-        filterNot(partitionColumns.contains)
+      val readDataColumns =
+        dataColumns
+          .filter(requiredAttributes.contains)
+          .filterNot(partitionColumns.contains)
       val outputSchema = readDataColumns.toStructType
-      logInfo(s"Output data schema: ${outputSchema.simpleString(5)}")
+      logInfo(s"Output Data Schema: ${outputSchema.simpleString(5)}")
 
-      val pushedDownFilters = dataFilters.flatMap(DataSourceStrategy.translateFilter)
-      logInfo(s"Pushed filters: ${pushedDownFilters.mkString(",")}")
+      val outputAttributes = readDataColumns ++ partitionColumns
 
-      val readFile = fsRelation.fileFormat.buildReaderWithPartitionValues(
-        sparkSession = sparkSession,
-        dataSchema = fsRelation.dataSchema,
-        partitionSchema = fsRelation.partitionSchema,
-        requiredSchema = outputSchema,
-        filters = pushedDownFilters,
-        options = fsRelation.options,
-        hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(fsRelation.options))
-
-      val plannedPartitions = fsRelation.bucketSpec match {
-        case Some(bucketing) if sparkSession.sessionState.conf.bucketingEnabled =>
-          logInfo(s"Planning with ${bucketing.numBuckets} buckets")
-          val bucketed =
-            selectedPartitions.flatMap { p =>
-              p.files.map { f =>
-                val hosts = getBlockHosts(getBlockLocations(f), 0, f.getLen)
-                PartitionedFile(p.values, f.getPath.toUri.toString, 0, f.getLen, hosts)
-              }
-            }.groupBy { f =>
-              BucketingUtils.
-                getBucketId(new Path(f.filePath).getName).
-                getOrElse(sys.error(s"Invalid bucket file ${f.filePath}"))
-            }
-
-          (0 until bucketing.numBuckets).map { bucketId =>
-            FilePartition(bucketId, bucketed.getOrElse(bucketId, Nil))
-          }
-
-        case _ =>
-          val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
-          val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
-          val defaultParallelism = sparkSession.sparkContext.defaultParallelism
-          val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
-          val bytesPerCore = totalBytes / defaultParallelism
-          val maxSplitBytes = Math.min(defaultMaxSplitBytes,
-            Math.max(openCostInBytes, bytesPerCore))
-          logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-            s"open cost is considered as scanning $openCostInBytes bytes.")
-
-          val splitFiles = selectedPartitions.flatMap { partition =>
-            partition.files.flatMap { file =>
-              val blockLocations = getBlockLocations(file)
-              val canBeSplit = fsRelation.fileFormat.isSplitable(sparkSession, fsRelation.options,
-                file.getPath)
-              if (canBeSplit) {
-                (0L until file.getLen by maxSplitBytes).map { offset =>
-                  val remaining = file.getLen - offset
-                  val size = if (remaining > maxSplitBytes) maxSplitBytes else remaining
-                  val hosts = getBlockHosts(blockLocations, offset, size)
-                  PartitionedFile(
-                    partition.values, file.getPath.toUri.toString, offset, size, hosts)
-                }
-              } else {
-                val hosts = getBlockHosts(blockLocations, 0, file.getLen)
-                Seq(PartitionedFile(
-                  partition.values, file.getPath.toUri.toString, 0, file.getLen, hosts))
-              }
-            }
-          }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
-
-          val partitions = new ArrayBuffer[FilePartition]
-          val currentFiles = new ArrayBuffer[PartitionedFile]
-          var currentSize = 0L
-
-          /** Add the given file to the current partition. */
-          def addFile(file: PartitionedFile): Unit = {
-            currentSize += file.length + openCostInBytes
-            currentFiles.append(file)
-          }
-
-          /** Close the current partition and move to the next. */
-          def closePartition(): Unit = {
-            if (currentFiles.nonEmpty) {
-              val newPartition =
-                FilePartition(
-                  partitions.size,
-                  currentFiles.toArray.toSeq) // Copy to a new Array.
-              partitions.append(newPartition)
-            }
-            currentFiles.clear()
-            currentSize = 0
-          }
-
-          // Assign files to partitions using "First Fit Decreasing" (FFD)
-          splitFiles.foreach { file =>
-            if (currentSize + file.length > maxSplitBytes) {
-              closePartition()
-            }
-            addFile(file)
-          }
-          closePartition()
-          partitions
-      }
-
-      val meta = Map(
-        "Format" -> fsRelation.fileFormat.toString,
-        "ReadSchema" -> outputSchema.simpleString,
-        PUSHED_FILTERS -> pushedDownFilters.mkString("[", ", ", "]"),
-        INPUT_PATHS -> catalog.paths.mkString(", "))
-
-      val scan = DataSourceScanExec.create(readDataColumns ++ partitionColumns,
-        new FileScanRDD(sparkSession, readFile, plannedPartitions), fsRelation, meta, table)
+      val scan =
+        FileSourceScanExec(
+          fsRelation,
+          outputAttributes,
+          outputSchema,
+          partitionKeyFilters.toSeq,
+          dataFilters,
+          table.map(_.identifier))
 
       val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
       val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)
@@ -217,45 +113,7 @@ object IndexSourceStrategy extends Strategy with Logging {
       }
 
       withProjections :: Nil
+
     case _ => Nil
-  }
-
-  private def getBlockLocations(file: FileStatus): Array[BlockLocation] = file match {
-    case f: LocatedFileStatus => f.getBlockLocations
-    case f => Array.empty[BlockLocation]
-  }
-
-  // Given locations of all blocks of a single file, `blockLocations`, and an `(offset, length)`
-  // pair that represents a segment of the same file, find out the block that contains the largest
-  // fraction the segment, and returns location hosts of that block. If no such block can be found,
-  // returns an empty array.
-  private def getBlockHosts(
-      blockLocations: Array[BlockLocation], offset: Long, length: Long): Array[String] = {
-    val candidates = blockLocations.map {
-      // The fragment starts from a position within this block
-      case b if b.getOffset <= offset && offset < b.getOffset + b.getLength =>
-        b.getHosts -> (b.getOffset + b.getLength - offset).min(length)
-
-      // The fragment ends at a position within this block
-      case b if offset <= b.getOffset && offset + length < b.getLength =>
-        b.getHosts -> (offset + length - b.getOffset).min(length)
-
-      // The fragment fully contains this block
-      case b if offset <= b.getOffset && b.getOffset + b.getLength <= offset + length =>
-        b.getHosts -> b.getLength
-
-      // The fragment doesn't intersect with this block
-      case b =>
-        b.getHosts -> 0L
-    }.filter { case (hosts, size) =>
-      size > 0L
-    }
-
-    if (candidates.isEmpty) {
-      Array.empty[String]
-    } else {
-      val (hosts, _) = candidates.maxBy { case (_, size) => size }
-      hosts
-    }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/IndexedDataSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/IndexedDataSource.scala
@@ -151,6 +151,7 @@ object IndexedDataSource {
   def resolveClassName(provider: String): String = provider match {
     case "parquet" => parquet
     case "org.apache.spark.sql.execution.datasources.parquet" => parquet
+    case "Parquet" => parquet
     case "ParquetFormat" => parquet
     case other => other
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/Metastore.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/Metastore.scala
@@ -51,13 +51,13 @@ private[sql] class Metastore(
   logInfo(s"Registered file system $fs")
 
   // cache of index catalogs per metastore
-  val onRemovalAction = new RemovalListener[Path, MetastoreIndexCatalog] {
-    override def onRemoval(rm: RemovalNotification[Path, MetastoreIndexCatalog]): Unit = {
+  val onRemovalAction = new RemovalListener[Path, MetastoreIndex] {
+    override def onRemoval(rm: RemovalNotification[Path, MetastoreIndex]): Unit = {
       logInfo(s"Evicting index ${rm.getKey}")
     }
   }
 
-  val cache: Cache[Path, MetastoreIndexCatalog] =
+  val cache: Cache[Path, MetastoreIndex] =
     CacheBuilder.newBuilder().
       maximumSize(16).
       expireAfterWrite(12, TimeUnit.HOURS).
@@ -187,7 +187,7 @@ private[sql] class Metastore(
    * Note that is this behaviour changes, cache should be updated accordingly.
    */
   def load(spec: IndexLocationSpec)
-      (func: FileStatus => MetastoreIndexCatalog): MetastoreIndexCatalog = {
+      (func: FileStatus => MetastoreIndex): MetastoreIndex = {
     val resolvedPath = location(spec)
     Option(cache.getIfPresent(resolvedPath)) match {
       case Some(cachedValue) =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreIndex.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreIndex.scala
@@ -30,16 +30,16 @@ import org.apache.spark.sql.types.StructType
 abstract class MetastoreIndex extends FileIndex with Logging {
 
   /** Fully qualified table path */
-  def tablePath(): Path
+  def tablePath: Path
 
   /** Schema of the partitioning columns, or the empty schema if the table is not partitioned. */
   def partitionSchema: StructType
 
   /** Index schema, used to prune files based on filters for indexed columns */
-  def indexSchema(): StructType
+  def indexSchema: StructType
 
   /** Return schema for listed files */
-  def dataSchema(): StructType
+  def dataSchema: StructType
 
   /** Set index filters for this catalog */
   def setIndexFilters(filters: Seq[Filter])

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/MetastoreSupport.scala
@@ -54,16 +54,16 @@ trait MetastoreSupport {
       tablePath: FileStatus,
       isAppend: Boolean,
       partitionSpec: PartitionSpec,
-      partitions: Seq[Partition],
+      partitions: Seq[PartitionDirectory],
       columns: Seq[Column]): Unit
 
   /**
-   * Load index into `MetastoreIndexCatalog`, which provides methods to return all files, apply
+   * Load index into `MetastoreIndex`, which provides methods to return all files, apply
    * filtering on discovered files and infer schema.
    * @param metastore current index metastore
    * @param indexDirectory index directory of metastore to load relevant data
    */
-  def loadIndex(metastore: Metastore, indexDirectory: FileStatus): MetastoreIndexCatalog
+  def loadIndex(metastore: Metastore, indexDirectory: FileStatus): MetastoreIndex
 
   /**
    * Delete index, this method should be overwritten when special handling of data inside index

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndex.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndex.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.execution.datasources.parquet
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.catalyst.{expressions, InternalRow}
+import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression, InterpretedPredicate}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources._
@@ -33,34 +33,47 @@ import com.github.lightcopy.util.SerializableFileStatus
  * Index catalog for Parquet tables.
  * Metastore is used mainly to provide Hadoop file system and/or configuration.
  */
-class ParquetIndexCatalog(
+class ParquetIndex(
     @transient val metastore: Metastore,
     @transient val indexMetadata: ParquetIndexMetadata)
-  extends MetastoreIndexCatalog {
+  extends MetastoreIndex {
+
+  // internal set of index filters that we reset every time when loading relation
+  private var internalIndexFilters: Seq[Filter] = Nil
 
   require(indexMetadata != null, "Parquet index metadata is null, serialized data is incorrect")
 
   override val tablePath: Path = new Path(indexMetadata.tablePath)
 
-  override val partitionSpec: PartitionSpec = indexMetadata.partitionSpec
+  override val partitionSchema: StructType = indexMetadata.partitionSpec.partitionColumns
 
   override lazy val dataSchema = indexMetadata.dataSchema
 
   override lazy val indexSchema = indexMetadata.indexSchema
 
+  override def setIndexFilters(filters: Seq[Filter]) = {
+    internalIndexFilters = filters
+  }
+
+  override def indexFilters: Seq[Filter] = internalIndexFilters
+
   override def listFilesWithIndexSupport(
-      filters: Seq[Expression], indexFilters: Seq[Filter]): Seq[Partition] = {
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression],
+      indexFilters: Seq[Filter]): Seq[PartitionDirectory] = {
     // select all parquet file statuses if partition schema is empty
+    val partitionSpec = indexMetadata.partitionSpec
     val allPartitions = indexMetadata.partitions
     val selectedPartitions: Seq[ParquetPartition] = if (partitionSpec.partitionColumns.isEmpty) {
       allPartitions
     } else {
       // here we need to check path for each partition leaf that it is contains partition directory
       // currently check is based on partitions having the same parsed values as directory
-      prunePartitions(filters, partitionSpec).flatMap { case PartitionDirectory(values, path) =>
-        allPartitions.filter { partition =>
-          partition.values == values
-        }
+      prunePartitions(partitionFilters, partitionSpec).flatMap {
+        case PartitionPath(values, path) =>
+          allPartitions.filter { partition =>
+            partition.values == values
+          }
       }
     }
 
@@ -80,21 +93,25 @@ class ParquetIndexCatalog(
 
     logDebug("Selected files after index filtering:\n\t" + filteredPartitions.mkString("\n\t"))
 
-    // convert it into sequence of Spark `Partition`s
+    // convert it into sequence of Spark `PartitionDirectory`s
     filteredPartitions.map { partition =>
-      Partition(partition.values, partition.files.map { file =>
+      PartitionDirectory(partition.values, partition.files.map { file =>
         SerializableFileStatus.toFileStatus(file.status)
       })
     }
   }
 
-  override def allFiles(): Seq[FileStatus] = indexMetadata.partitions.flatMap { partition =>
-    partition.files.map { parquetFile => SerializableFileStatus.toFileStatus(parquetFile.status) }
-  }
+  override lazy val inputFiles: Array[String] = indexMetadata.partitions.flatMap { partition =>
+    partition.files.map { parquetFile => parquetFile.status.path }
+  }.toArray
+
+  override lazy val sizeInBytes: Long = indexMetadata.partitions.flatMap { partition =>
+    partition.files.map { parquetFile => parquetFile.status.length }
+  }.sum
 
   private[parquet] def prunePartitions(
       predicates: Seq[Expression],
-      partitionSpec: PartitionSpec): Seq[PartitionDirectory] = {
+      partitionSpec: PartitionSpec): Seq[PartitionPath] = {
     val PartitionSpec(partitionColumns, partitions) = partitionSpec
     val partitionColumnNames = partitionColumns.map(_.name).toSet
     val partitionPruningPredicates = predicates.filter {
@@ -111,14 +128,14 @@ class ParquetIndexCatalog(
       })
 
       val selected = partitions.filter {
-        case PartitionDirectory(values, _) => boundPredicate(values)
+        case PartitionPath(values, _) => boundPredicate.eval(values)
       }
-
       logInfo {
         val total = partitions.length
         val selectedSize = selected.length
         val percentPruned = (1 - selectedSize.toDouble / total.toDouble) * 100
-        s"Selected $selectedSize partitions out of $total, pruned $percentPruned% partitions."
+        s"Selected $selectedSize partitions out of $total, " +
+          s"pruned ${if (total == 0) "0" else s"$percentPruned%"} partitions."
       }
 
       selected

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndex.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndex.scala
@@ -45,7 +45,7 @@ class ParquetIndex(
 
   override val tablePath: Path = new Path(indexMetadata.tablePath)
 
-  override val partitionSchema: StructType = indexMetadata.partitionSpec.partitionColumns
+  override lazy val partitionSchema: StructType = indexMetadata.partitionSpec.partitionColumns
 
   override lazy val dataSchema = indexMetadata.dataSchema
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupport.scala
@@ -43,7 +43,7 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
 
   override def loadIndex(
       metastore: Metastore,
-      indexDirectory: FileStatus): MetastoreIndexCatalog = {
+      indexDirectory: FileStatus): MetastoreIndex = {
     val readDir = tableMetadataLocation(indexDirectory.getPath)
     if (!metastore.fs.exists(readDir)) {
       throw new IOException(s"Path $readDir for table metadata does not exist")
@@ -89,7 +89,7 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
       logInfo(s"Loaded all filter statistics for catalog in $timeMs ms")
     }
 
-    new ParquetIndexCatalog(metastore, indexMetadata)
+    new ParquetIndex(metastore, indexMetadata)
   }
 
   override def createIndex(
@@ -98,7 +98,7 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
       tablePath: FileStatus,
       isAppend: Boolean,
       partitionSpec: PartitionSpec,
-      partitions: Seq[Partition],
+      partitions: Seq[PartitionDirectory],
       columns: Seq[Column]): Unit = {
     require(partitions.nonEmpty, "Empty partitions provided")
     if (isAppend) {
@@ -180,7 +180,9 @@ case class ParquetMetastoreSupport() extends MetastoreSupport with Logging {
    * If list of column names is empty, infer all available columns in schema.
    */
   private[parquet] def inferIndexSchema(
-      metastore: Metastore, partitions: Seq[Partition], columns: Seq[String]): StructType = {
+      metastore: Metastore,
+      partitions: Seq[PartitionDirectory],
+      columns: Seq[String]): StructType = {
     val conf = metastore.session.sessionState.newHadoopConf()
     val status = partitions.head.files.head
 

--- a/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/IndexConf.scala
@@ -16,24 +16,24 @@
 
 package org.apache.spark.sql.internal
 
-import org.apache.spark.internal.config._
+import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.sql.SparkSession
 
 object IndexConf {
-  import SQLConf.SQLConfigBuilder
+  import SQLConf.buildConf
 
-  val METASTORE_LOCATION = SQLConfigBuilder("spark.sql.index.metastore").
+  val METASTORE_LOCATION = buildConf("spark.sql.index.metastore").
     doc("Metastore location or root directory to store index information, will be created " +
       "if path does not exist").
     stringConf.
     createWithDefault("")
 
-  val CREATE_IF_NOT_EXISTS = SQLConfigBuilder("spark.sql.index.createIfNotExists").
+  val CREATE_IF_NOT_EXISTS = buildConf("spark.sql.index.createIfNotExists").
     doc("When set to true, creates index if one does not exist in metastore for the table").
     booleanConf.
     createWithDefault(false)
 
-  val NUM_PARTITIONS = SQLConfigBuilder("spark.sql.index.partitions").
+  val NUM_PARTITIONS = buildConf("spark.sql.index.partitions").
     doc("When creating index uses this number of partitions. If value is non-positive or not " +
       "provided then uses `sc.defaultParallelism * 3` or `spark.sql.shuffle.partitions` " +
       "configuration value, whichever is smaller").
@@ -41,21 +41,21 @@ object IndexConf {
     createWithDefault(0)
 
   val PARQUET_FILTER_STATISTICS_ENABLED =
-    SQLConfigBuilder("spark.sql.index.parquet.filter.enabled").
+    buildConf("spark.sql.index.parquet.filter.enabled").
     doc("When set to true, writes filter statistics for indexed columns when creating table " +
       "index, otherwise only min/max statistics are used. Filter statistics are always used " +
       "during filtering stage, if applicable").
     booleanConf.
     createWithDefault(true)
 
-  val PARQUET_FILTER_STATISTICS_TYPE = SQLConfigBuilder("spark.sql.index.parquet.filter.type").
+  val PARQUET_FILTER_STATISTICS_TYPE = buildConf("spark.sql.index.parquet.filter.type").
     doc("When filter statistics enabled, selects type of statistics to use when creating index. " +
       "Available options are `bloom`, `dict`").
     stringConf.
     createWithDefault("bloom")
 
   val PARQUET_FILTER_STATISTICS_EAGER_LOADING =
-    SQLConfigBuilder("spark.sql.index.parquet.filter.eagerLoading").
+    buildConf("spark.sql.index.parquet.filter.eagerLoading").
     doc("When set to true, read and load all filter statistics in memory the first time catalog " +
       "is resolved, otherwise load them lazily as needed when evaluating predicate. " +
       "Eager loading removes IO of reading filter data from disk, but requires extra memory").

--- a/src/main/scala/org/apache/spark/sql/sources/filters.scala
+++ b/src/main/scala/org/apache/spark/sql/sources/filters.scala
@@ -19,4 +19,6 @@ package org.apache.spark.sql.sources
 /**
  * Trivial filter to resolve directly, provides empty list of references.
  */
-case class Trivial(value: Boolean) extends Filter
+case class Trivial(value: Boolean) extends Filter {
+  override def references: Array[String] = findReferences(value)
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreIndexSuite.scala
@@ -27,12 +27,15 @@ import com.github.lightcopy.testutil.implicits._
 
 // Test catalog to check internal methods
 private[datasources] class TestIndex extends MetastoreIndex {
+  private var internalIndexFilters: Seq[Filter] = Nil
   override def tablePath(): Path = ???
   override def partitionSchema: StructType = ???
   override def indexSchema: StructType = ???
   override def dataSchema: StructType = ???
-  override def setIndexFilters(filters: Seq[Filter]) = { }
-  override def indexFilters: Seq[Filter] = ???
+  override def setIndexFilters(filters: Seq[Filter]) = {
+    internalIndexFilters = filters
+  }
+  override def indexFilters: Seq[Filter] = internalIndexFilters
   override def listFilesWithIndexSupport(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression],

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -366,7 +366,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       val metastore = testMetastore(spark, dir)
       val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
       val path = metastore.location(spec)
-      metastore.cache.put(path, new TestIndexCatalog())
+      metastore.cache.put(path, new TestIndex())
       metastore.cache.asMap.size should be (1)
 
       metastore.create(spec, SaveMode.ErrorIfExists) {
@@ -413,7 +413,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       val metastore = testMetastore(spark, dir)
       val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
       val path = metastore.location(spec)
-      metastore.cache.put(path, new TestIndexCatalog())
+      metastore.cache.put(path, new TestIndex())
       metastore.cache.asMap.size should be (1)
 
       mkdirs(path)
@@ -432,7 +432,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       val metastore = testMetastore(spark, dir)
       val spec = SourceLocationSpec("identifier", new Path("/tmp/table"))
       val path = metastore.location(spec)
-      metastore.cache.put(path, new TestIndexCatalog())
+      metastore.cache.put(path, new TestIndex())
       metastore.delete(spec) {
         case status => // no-op
       }
@@ -451,7 +451,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       val metastore = testMetastore(spark, dir)
       val err = intercept[IOException] {
         metastore.load(SourceLocationSpec("identifier", new Path("/tmp/table"))) {
-          case status => new TestIndexCatalog()
+          case status => new TestIndex()
         }
       }
       assert(err.getMessage.contains("Index does not exist"))
@@ -466,7 +466,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       mkdirs(location)
       val err = intercept[IOException] {
         metastore.load(spec) { case status =>
-          new TestIndexCatalog()
+          new TestIndex()
         }
       }
       assert(err.getMessage.contains("Possibly corrupt index, could not find success mark"))
@@ -483,7 +483,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       var triggered = false
       metastore.load(spec) { case status =>
         triggered = true
-        new TestIndexCatalog()
+        new TestIndex()
       }
       triggered should be (true)
       // check that cache also contains entry
@@ -500,7 +500,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       Metastore.markSuccess(fs, location)
 
       val catalog1 = metastore.load(spec) {
-        case status => new TestIndexCatalog()
+        case status => new TestIndex()
       }
       val catalog2 = metastore.load(spec) {
         case status =>

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/MetastoreSuite.scala
@@ -61,12 +61,20 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
     stopSparkSession()
   }
 
+  /** Partially check permissions, actual should match exactly or include expected */
+  def implyPermission(actual: FsPermission, expected: FsPermission): Boolean = {
+    actual.getUserAction.implies(expected.getUserAction) &&
+    actual.getGroupAction.implies(expected.getGroupAction) &&
+    actual.getOtherAction.implies(expected.getOtherAction)
+  }
+
   test("create non-existent directory for metastore") {
     withTempDir { dir =>
       val metastore = testMetastore(spark, dir / "test_metastore")
       metastore.metastoreLocation.endsWith("test_metastore") should be (true)
       val status = fs.getFileStatus(new Path(metastore.metastoreLocation))
       status.isDirectory should be (true)
+      // should match exactly
       status.getPermission should be (Metastore.METASTORE_PERMISSION)
     }
   }
@@ -85,6 +93,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.metastoreLocation should be ("file:" + dir.toString)
       val status = fs.getFileStatus(new Path(metastore.metastoreLocation))
       status.isDirectory should be (true)
+      // should amtch exactly
       status.getPermission should be (Metastore.METASTORE_PERMISSION)
     }
   }
@@ -190,7 +199,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.create(spec, SaveMode.Append) { case (status, isAppend) =>
         triggered = true
         status.isDirectory should be (true)
-        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        assert(implyPermission(status.getPermission, Metastore.METASTORE_PERMISSION))
         isAppend should be (false)
       }
       triggered should be (true)
@@ -207,7 +216,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.create(spec, SaveMode.Overwrite) { case (status, isAppend) =>
         triggered = true
         status.isDirectory should be (true)
-        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        assert(implyPermission(status.getPermission, Metastore.METASTORE_PERMISSION))
         isAppend should be (false)
       }
       triggered should be (true)
@@ -224,7 +233,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.create(spec, SaveMode.ErrorIfExists) { case (status, isAppend) =>
         triggered = true
         status.isDirectory should be (true)
-        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        assert(implyPermission(status.getPermission, Metastore.METASTORE_PERMISSION))
         isAppend should be (false)
       }
       triggered should be (true)
@@ -241,7 +250,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.create(spec, SaveMode.Ignore) { case (status, isAppend) =>
         triggered = true
         status.isDirectory should be (true)
-        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        assert(implyPermission(status.getPermission, Metastore.METASTORE_PERMISSION))
         isAppend should be (false)
       }
       triggered should be (true)
@@ -260,7 +269,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.create(spec, SaveMode.Append) { case (status, isAppend) =>
         triggered = true
         status.isDirectory should be (true)
-        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        assert(implyPermission(status.getPermission, Metastore.METASTORE_PERMISSION))
         isAppend should be (true)
         // original file should still exist in the folder
         metastore.fs.exists(path / "metadata") should be (true)
@@ -281,7 +290,7 @@ class MetastoreSuite extends UnitTestSuite with SparkLocal with TestMetastore {
       metastore.create(spec, SaveMode.Overwrite) { case (status, isAppend) =>
         triggered = true
         status.isDirectory should be (true)
-        status.getPermission should be (Metastore.METASTORE_PERMISSION)
+        assert(implyPermission(status.getPermission, Metastore.METASTORE_PERMISSION))
         isAppend should be (false)
         // original file should be deleted
         metastore.fs.exists(path / "metadata") should be (false)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFiltersSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexFiltersSuite.scala
@@ -37,7 +37,9 @@ private[parquet] case class TestInFilter(values: Seq[Any]) extends ColumnFilterS
   override def isLoaded: Boolean = true
 }
 
-private[parquet] case class TestUnsupportedFilter() extends Filter
+private[parquet] case class TestUnsupportedFilter() extends Filter {
+  override def references: Array[String] = Array.empty
+}
 
 class ParquetIndexFiltersSuite extends UnitTestSuite with SparkLocal {
   override def beforeAll {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIndexReadSupportSuite.scala
@@ -74,7 +74,7 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
     val container = new BufferRecordContainer()
     container.init(numFields = 1)
     container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"),
-      Binary.fromByteArray(new Array[Byte](12), 0, 12))
+      Binary.fromConstantByteArray(new Array[Byte](12), 0, 12))
     container.getByIndex(0).isInstanceOf[java.sql.Timestamp] should be (true)
   }
 
@@ -122,14 +122,14 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
     val container = new BufferRecordContainer()
     container.init(numFields = 1)
     var err = intercept[AssertionError] {
-      val bin = Binary.fromByteArray(arr, 0, 11)
+      val bin = Binary.fromConstantByteArray(arr, 0, 11)
       container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"), bin)
     }
     assert(err.getMessage.contains(
       "Timestamps (with nanoseconds) are expected to be stored in 12-byte long binaries"))
 
     err = intercept[AssertionError] {
-      val bin = Binary.fromByteArray(arr, 0, 13)
+      val bin = Binary.fromConstantByteArray(arr, 0, 13)
       container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"), bin)
     }
   }
@@ -139,7 +139,7 @@ class ParquetIndexReadSupportSuite extends UnitTestSuite {
     container.init(numFields = 1)
     // same as 110000000000L or 1970-01-02 18:33:20.0
     val arr = Array[Byte](0, -32, -99, -51, 118, 21, 0, 0, -115, 61, 37, 0)
-    val bin = Binary.fromByteArray(arr, 0, arr.length)
+    val bin = Binary.fromConstantByteArray(arr, 0, arr.length)
     container.setParquetBinary(0, new PrimitiveType(REQUIRED, INT96, "a"), bin)
     container.getByIndex(0) should be (DateTimeUtils.toJavaTimestamp(110000000000L))
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetMetastoreSupportSuite.scala
@@ -321,7 +321,7 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         val location = metastore.location(spec)
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
-          asInstanceOf[ParquetIndexCatalog]
+          asInstanceOf[ParquetIndex]
         catalog.indexMetadata.partitions.nonEmpty should be (true)
         catalog.indexMetadata.partitions.foreach { partition =>
           partition.files.nonEmpty should be (true)
@@ -356,7 +356,7 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         val location = metastore.location(spec)
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
-          asInstanceOf[ParquetIndexCatalog]
+          asInstanceOf[ParquetIndex]
         catalog.indexMetadata.partitions.nonEmpty should be (true)
         catalog.indexMetadata.partitions.foreach { partition =>
           partition.files.nonEmpty should be (true)
@@ -392,7 +392,7 @@ class ParquetMetastoreSupportSuite extends UnitTestSuite with SparkLocal with Te
         val location = metastore.location(spec)
 
         val catalog = support.loadIndex(metastore, fs.getFileStatus(location)).
-          asInstanceOf[ParquetIndexCatalog]
+          asInstanceOf[ParquetIndex]
         catalog.indexMetadata.partitions.nonEmpty should be (true)
         catalog.indexMetadata.partitions.foreach { partition =>
           partition.files.nonEmpty should be (true)


### PR DESCRIPTION
This PR adds support for Spark 2.2+. 
I will add Spark 2.1 support separately, because of some method signature changes, that I do not want to cover with reflection.

Closes #77 
Closes #78