### PR TITLE
Add support for python 3, deprecate python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ Currently only these types are supported for indexed columns:
 - Scala 2.11.x
 - JDK 8+
 
+
 > Previous versions have support for Scala 2.10.x and JDK 7, see README for corresponding tag or
 > branch. See build section to compile for desired Java/Scala versions.
+
+And, if using the Python API, Python 3.x with a working version of `pyspark`.
+
+> The current version parts ways with Python 2 definitely. Python 2.7 is officially unsupported,
+> which is the reason why we opted not to write a retrocompatible wrapper around the Scala API.
 
 ## Linking
 The `parquet-index` package can be added to Spark by using the `--packages` command line option.
@@ -75,7 +81,7 @@ For example, run this to include it when starting `spark-shell` (Scala 2.11.x):
 ```shell
  $SPARK_HOME/bin/spark-shell --packages lightcopy:parquet-index:0.4.0-s_2.11
 ```
-Or for `pyspark` to use Python API (see section below):
+Or for `pyspark` to use Python 3 API (see section below):
 ```shell
 $SPARK_HOME/bin/pyspark --packages lightcopy:parquet-index:0.4.0-s_2.11
 ```
@@ -176,8 +182,8 @@ Dataset<Row> df = context.index().parquet("table.parquet").filter("col2 = 'c'");
 context.index().delete().parquet("table.parquet");
 ```
 
-### Python API
-Following example shows usage of Python API (runnable in `pyspark`)
+### Python 3.x API
+Following example shows usage of Python 3 API (runnable in `pyspark`)
 ```python
 from lightcopy.index import QueryContext
 
@@ -205,7 +211,7 @@ context.index.delete.parquet('table.parquet')
 Package also supports index for persistent tables that are saved using `saveAsTable()` in Parquet
 format and accessible using `spark.table(tableName)`. When using with persistent tables, just
 replace `.parquet(path_to_the_file)` with `.table(table_name)`. API is available in Scala, Java and
-Python.
+Python 3.
 
 #### Scala
 ```scala
@@ -246,7 +252,7 @@ Dataset<Row> df = context.index().table("table_name").filter("col2 = 'c'");
 context.index().delete().table("table_name");
 ```
 
-#### Python
+#### Python 3
 ```python
 from lightcopy.index import QueryContext
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Currently only these types are supported for indexed columns:
 
 And, if using the Python API, Python 3.x with a working version of `pyspark`.
 
-> The current version parts ways with Python 2 definitely. Python 2.7 is officially unsupported,
+> The current version parts ways with Python 2 definitely. Python 2.7 is officially deprecated,
 > which is the reason why we opted not to write a retrocompatible wrapper around the Scala API.
 
 ## Linking

--- a/python/run_tests.py
+++ b/python/run_tests.py
@@ -77,19 +77,19 @@ def check_headers(filepath, skip_empty=True):
     exit_code = 0
     with open(filepath, 'r') as stream:
         if stream.readline().strip() != "#!/usr/bin/env python":
-            print "ERROR: Missing '#!/usr/bin/env python' as first line in '%s'" % filepath
+            print("ERROR: Missing '#!/usr/bin/env python' as first line in '%s'" % filepath)
             exit_code = 1
         if stream.readline().strip() != "# -*- coding: UTF-8 -*-":
-            print "ERROR: Missing '# -*- coding: UTF-8 -*-' as second line in '%s'" % filepath
+            print("ERROR: Missing '# -*- coding: UTF-8 -*-' as second line in '%s'" % filepath)
             exit_code = 1
         # next line must be empty
         if stream.readline().strip():
-            print "ERROR: No new line after shebang headers in '%s'" % filepath
+            print("ERROR: No new line after shebang headers in '%s'" % filepath)
             exit_code = 1
         # read next 15 lines and check license header
         header = [stream.readline().strip() for x in range(0, 15)]
         if '\n'.join(header) != license_header:
-            print "ERROR: Wrong license header in '%s'" % filepath
+            print("ERROR: Wrong license header in '%s'" % filepath)
             exit_code = 1
     return exit_code
 

--- a/python/src/lightcopy/index.py
+++ b/python/src/lightcopy/index.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-from types import DictType
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.session import SparkSession
 
@@ -261,7 +260,7 @@ class DataFrameIndexManager(object):
         :param: opts dictionary
         :return: self
         """
-        if not isinstance(opts, DictType):
+        if not isinstance(opts, dict):
             msg = 'Expected <dict>, found %s' % (opts)
             raise AttributeError(msg)
         for (key, value) in opts.items():

--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -35,32 +35,32 @@ def addTests(module_name):
         batch = loadSuites(module)
         suites.addTest(batch)
     else:
-        print "@skip: '%s' tests" % module_name
+        print("@skip: '%s' tests" % module_name)
 
 # Load test suites for module
 def loadSuites(module):
     gsuite = unittest.TestSuite()
     for suite in module.suites():
-        print "Adding %s" % suite
+        print("Adding %s" % suite)
         gsuite.addTest(unittest.TestLoader().loadTestsFromTestCase(suite))
     return gsuite
 
 def collectSystemTests():
-    for test_name in RUN_TESTS.keys():
+    for test_name in list(RUN_TESTS.keys()):
         addTests(test_name)
 
 def main():
-    print ""
-    print "== Gathering tests info =="
-    print "-" * 70
+    print("")
+    print("== Gathering tests info ==")
+    print("-" * 70)
     collectSystemTests()
-    print ""
-    print "== Running tests =="
-    print "-" * 70
+    print("")
+    print("== Running tests ==")
+    print("-" * 70)
     results = unittest.TextTestRunner(verbosity=2).run(suites)
-    num = len([x for x in RUN_TESTS.values() if not x])
-    print "%s Number of test modules skipped: %d" %("OK" if num == 0 else "WARN", num)
-    print ""
+    num = len([x for x in list(RUN_TESTS.values()) if not x])
+    print("%s Number of test modules skipped: %d" %("OK" if num == 0 else "WARN", num))
+    print("")
     # Fail if there is at least 1 error or failure
     if results and len(results.failures) == 0 and len(results.errors) == 0:
         return 0

--- a/python/test/test_index.py
+++ b/python/test/test_index.py
@@ -205,7 +205,7 @@ class IndexSuite(unittest.TestCase):
             context.index.create.indexByAll().table(tableName)
             res1 = context.index.table(tableName).filter('id = 3').collect()
             res2 = self.spark.table(tableName).filter('id = 3').collect()
-            self.assertEquals(res1, res2)
+            self.assertEqual(res1, res2)
         finally:
             self.spark.sql("drop table " + tableName)
 


### PR DESCRIPTION
This patch adds support for python 3, but deprecates python 2 at the moment.

One could achieve a better result by using the `six` library, or some `from __future__ import print` magic, but it's also true that Python 2 is officially in EOL since January 1, 2020.

I used the 2to3 tool to convert the code and so far it seems to work.